### PR TITLE
added linking evaluation

### DIFF
--- a/notebooks/tasks/demo_qwen.ipynb
+++ b/notebooks/tasks/demo_qwen.ipynb
@@ -154,7 +154,8 @@
     "langid = utils.safe_import(\"langid\")\n",
     "regex = utils.safe_import(\"regex\")\n",
     "pl = utils.safe_import(\"polars\")\n",
-    "pypdf = utils.safe_import(\"pypdf\")"
+    "pypdf = utils.safe_import(\"pypdf\")\n",
+    "tabulate = utils.safe_import(\"tabulate\")"
    ]
   },
   {
@@ -298,15 +299,15 @@
     "    spacy_model.add_pipe(\"sentencizer\")\n",
     "    preprocessed_text = spacy_model(text)\n",
     "    sentences = [{\"id\": sentence_id, \n",
-    "                  \"start\": sentence.start_char, \n",
-    "                  \"end\": sentence.end_char, \n",
+    "                  \"start_char\": sentence.start_char, \n",
+    "                  \"end_char\": sentence.end_char, \n",
     "                  \"text\": sentence.text} for sentence_id, sentence in enumerate(preprocessed_text.sents)]\n",
     "    tok2sent = {token.i: sentence_id for sentence_id, sentence in enumerate(preprocessed_text.sents) \n",
     "                                     for token in sentence}\n",
     "    tokens = [{\"id\": token.i,\n",
-    "               \"text\": token.text,\n",
-    "               \"start\": token.idx,\n",
-    "               \"end\": token.idx + len(token.text),\n",
+    "               \"entity_text\": token.text,\n",
+    "               \"start_char\": token.idx,\n",
+    "               \"end_char\": token.idx + len(token.text),\n",
     "               \"ws\": token.whitespace_ != \"\",\n",
     "               \"is_punct\": token.is_punct,\n",
     "               \"sent_id\": tok2sent.get(token.i)} for token in preprocessed_text]\n",
@@ -441,7 +442,7 @@
      "text": [
       "Processing text 100\n",
       "Finished processing\n",
-      "{'meta': {'language_id': 'en', 'id': 'C. 0115', 'data_source': 'EMT', 'char_count': 5, 'token_count': 23, 'sentence_count': 4}, 'sentences': [{'id': 0, 'start': 0, 'end': 28, 'text': 'Statuette of the god Anubis.'}, {'id': 1, 'start': 29, 'end': 36, 'text': 'Bronze.'}, {'id': 2, 'start': 37, 'end': 85, 'text': 'Late Period (722-332 BC).. Acquired before 1882.'}, {'id': 3, 'start': 86, 'end': 92, 'text': 'C. 115'}], 'tokens': [{'id': 0, 'text': 'Statuette', 'start': 0, 'end': 9, 'ws': True, 'is_punct': False, 'sent_id': 0}, {'id': 1, 'text': 'of', 'start': 10, 'end': 12, 'ws': True, 'is_punct': False, 'sent_id': 0}, {'id': 2, 'text': 'the', 'start': 13, 'end': 16, 'ws': True, 'is_punct': False, 'sent_id': 0}, '...']}\n"
+      "{'meta': {'language_id': 'en', 'id': 'C. 0115', 'data_source': 'EMT', 'char_count': 5, 'token_count': 23, 'sentence_count': 4}, 'sentences': [{'id': 0, 'start_char': 0, 'end_char': 28, 'text': 'Statuette of the god Anubis.'}, {'id': 1, 'start_char': 29, 'end_char': 36, 'text': 'Bronze.'}, {'id': 2, 'start_char': 37, 'end_char': 85, 'text': 'Late Period (722-332 BC).. Acquired before 1882.'}, {'id': 3, 'start_char': 86, 'end_char': 92, 'text': 'C. 115'}], 'tokens': [{'id': 0, 'entity_text': 'Statuette', 'start_char': 0, 'end_char': 9, 'ws': True, 'is_punct': False, 'sent_id': 0}, {'id': 1, 'entity_text': 'of', 'start_char': 10, 'end_char': 12, 'ws': True, 'is_punct': False, 'sent_id': 0}, {'id': 2, 'entity_text': 'the', 'start_char': 13, 'end_char': 16, 'ws': True, 'is_punct': False, 'sent_id': 0}, '...']}\n"
      ]
     }
    ],
@@ -651,7 +652,7 @@
    },
    "outputs": [],
    "source": [
-    "def extract_entities_from_markdown(texts_output):\n",
+    "def extract_entities_from_markdown(texts_output, text_id, text_cleaned):\n",
     "    \"\"\"Extract the locations and labels of the entities from the markdown and return these\"\"\"\n",
     "    pattern = r'\\[([^\\]]+)\\]\\(([^)]+)\\)'\n",
     "    text_prefix = \"\"\n",
@@ -659,14 +660,16 @@
     "    entities = []\n",
     "    for match in regex.finditer(pattern, texts_output):\n",
     "        text_prefix += texts_output[current_char: match.start()]\n",
-    "        entities.append({\"text\": match.group(1),\n",
+    "        entities.append({\"entity_text\": match.group(1),\n",
     "                         \"label\": match.group(2),\n",
-    "                         \"start_char\": len(text_prefix),\n",
-    "                         \"end_char\": len(text_prefix) + len(match.group(1))})\n",
+    "                         \"text\": text_cleaned,\n",
+    "                         \"text_id\": text_id})\n",
+    "                         #\"start_char\": len(text_prefix),\n",
+    "                         #\"end_char\": len(text_prefix) + len(match.group(1))})\n",
     "        text_prefix += match.group(1)\n",
     "        current_char = match.end()\n",
     "    text_prefix += texts_output[current_char:]\n",
-    "    return entities, text_prefix"
+    "    return utils.add_char_offsets_to_entities_per_text(entities), text_prefix"
    ]
   },
   {
@@ -754,7 +757,7 @@
     {
      "data": {
       "text/html": [
-       "**Amulet depicting the god <span style=\"border: 1px solid black; color: red;\">Harpocrates</span>**"
+       "Amulet depicting the god <span style=\"border: 1px solid black; color: red;\">Harpocrates</span>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -773,7 +776,7 @@
     {
      "data": {
       "text/html": [
-       "**Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. <span style=\"border: 1px solid black; color: red;\">Drovetti</span> collection (1824). C. 515**"
+       "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. <span style=\"border: 1px solid black; color: red;\">Drovetti</span> collection (1824). C. 515"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -785,12 +788,14 @@
    ],
    "source": [
     "entities_all = []\n",
-    "for index, text in enumerate(texts_output):\n",
-    "    entities, text_llm_output = extract_entities_from_markdown(text)\n",
-    "    entities_all.append({\"entities\": entities, \"text_llm_output\": text_llm_output})\n",
-    "    if index < 5:\n",
-    "        check_llm_output_text(text_llm_output, texts_input[index])\n",
-    "        display(HTML(utils.mark_entities_in_text(text_llm_output, entities)))"
+    "for text_id, text in enumerate(texts_output):\n",
+    "    entities, text_llm_output = extract_entities_from_markdown(text, text_id, texts_input[text_id])\n",
+    "    entities_all.append({\"entities\": entities, \n",
+    "                         \"text_cleaned\": texts_input[text_id],\n",
+    "                         \"text_llm_output\": text_llm_output})\n",
+    "    if text_id < 5:\n",
+    "        check_llm_output_text(text_llm_output, texts_input[text_id])\n",
+    "        display(HTML(utils.mark_entities_in_text(texts_input[text_id], entities)))"
    ]
   },
   {
@@ -846,18 +851,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "warning: machine token boundary error: text_id = 9; entity: {'start_char': 15, 'end_char': 26, 'text': 'Amenhotep I', 'label': 'PERSON'}; token: {'id': 3, 'text': 'Amenhotep', 'start': 15, 'end': 24, 'ws': True, 'is_punct': False, 'sent_id': 0}\n",
-      "true: 1 pred: 1\n",
-      "data_format_true [[3790]]\n",
-      "data_format_pred [[3790]]\n",
-      "\u001b[1mHIPE Analysis\u001b[0m\n",
-      "╒══════════╤═══════════╤═══════════╤════════════╕\n",
-      "│ Label    │   P_micro │   R_micro │   F1_micro │\n",
-      "╞══════════╪═══════════╪═══════════╪════════════╡\n",
-      "│ PERSON   │      96.1 │      84.2 │       89.8 │\n",
-      "├──────────┼───────────┼───────────┼────────────┤\n",
-      "│ LOCATION │      76.9 │      76.9 │       76.9 │\n",
-      "╘══════════╧═══════════╧═══════════╧════════════╛\n"
+      "warning: machine token boundary error: text_id = 9; entity: {'entity_text': 'Amenhotep I', 'label': 'PERSON', 'text': 'Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372', 'text_id': 9, 'start_char': 15, 'end_char': 26}; token: {'id': 3, 'entity_text': 'Amenhotep', 'start_char': 15, 'end_char': 24, 'ws': True, 'is_punct': False, 'sent_id': 0}\n"
      ]
     }
    ],
@@ -868,7 +862,41 @@
     "text_tokens = utils.insert_machine_entities_in_tokens(input_data)\n",
     "gold_lines = utils.read_lines_from_file(NER_ANNOTATIONS_FILE)\n",
     "text_tokens = utils.add_gold_entities_to_tokens(gold_lines, text_tokens)\n",
-    "utils.evaluate(text_tokens, clef_evaluation)"
+    "#utils.hipe_evaluate(text_tokens, clef_evaluation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The HIPE-scorer produces optimistic scores. Therefore we evaluate the recognition task with a local evaluation function: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒══════════╤═════════════╤══════════╤══════╕\n",
+      "│ Label    │   Precision │   Recall │   F1 │\n",
+      "╞══════════╪═════════════╪══════════╪══════╡\n",
+      "│ LOCATION │        84.3 │     77.8 │ 80.9 │\n",
+      "├──────────┼─────────────┼──────────┼──────┤\n",
+      "│ PERSON   │        90.8 │     84.6 │ 87.6 │\n",
+      "├──────────┼─────────────┼──────────┼──────┤\n",
+      "│ ALL      │        88.6 │     82.3 │ 85.3 │\n",
+      "╘══════════╧═════════════╧══════════╧══════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_entities = utils.get_entities_from_token_lists(text_tokens, \"gold_tag\")\n",
+    "machine_entities = utils.get_entities_from_token_lists(text_tokens, \"machine_tag\")\n",
+    "correct, missed, wrong = utils.evaluate(gold_entities, machine_entities, \"gold_tag\", \"machine_tag\", [\"LOCATION\", \"PERSON\", \"ALL\"])"
    ]
   },
   {
@@ -928,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -952,7 +980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,8 +993,8 @@
     "        entities_per_text[entity[\"text_id\"]][entity[\"entity_text\"]] = entity\n",
     "    for text_id, text in enumerate(texts_input):\n",
     "        for entity in text[\"entities\"]:\n",
-    "            if text_id in entities_per_text and entity[\"text\"] in entities_per_text[text_id]:\n",
-    "                entity[\"wikidata_id\"] = entities_per_text[text_id][entity[\"text\"]][\"wikidata_id\"]\n",
+    "            if text_id in entities_per_text and entity[\"entity_text\"] in entities_per_text[text_id]:\n",
+    "                entity[\"wikidata_id\"] = entities_per_text[text_id][entity[\"entity_text\"]][\"wikidata_id\"]\n",
     "    return texts_input"
    ]
   },
@@ -981,21 +1009,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'text_cleaned': 'Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115', 'entities': []}\n"
+      "{'text_cleaned': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'entities': [{'entity_text': 'Amenhotep III', 'label': 'PERSON', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 81, 'end_char': 94}, {'entity_text': 'Thebes', 'label': 'LOCATION', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 111, 'end_char': 117}, {'entity_text': 'Drovetti', 'label': 'PERSON', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 120, 'end_char': 128}]}\n"
      ]
     }
    ],
    "source": [
     "texts_input = copy.deepcopy(input_data)\n",
-    "print({\"text_cleaned\": texts_input[0][\"text_cleaned\"], \n",
-    "       \"entities\": texts_input[0][\"entities\"]})"
+    "print({\"text_cleaned\": texts_input[1][\"text_cleaned\"], \n",
+    "       \"entities\": texts_input[1][\"entities\"]})"
    ]
   },
   {
@@ -1016,7 +1044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,13 +1072,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
     "def extract_entities_from_ner_input(texts_input):\n",
     "    \"\"\"For each entity in the input text return the entity text, context text and context text id\"\"\" \n",
-    "    return [{\"entity_text\": entity[\"text\"],\n",
+    "    return [{\"entity_text\": entity[\"entity_text\"],\n",
     "             \"text_id\": index,\n",
     "             \"text\": text[\"text_cleaned\"]} \n",
     "            for index, text in enumerate(texts_input) for entity in text[\"entities\"]]"
@@ -1058,7 +1086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,7 +1120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1100,7 +1128,7 @@
      "output_type": "stream",
      "text": [
       "Finished processing\n",
-      "️✅ Saved data to file disambiguation_cache_wikidata_353f41738ee289500f12db68e8af1c5095a928e0.json\n",
+      "️✅ Saved data to file disambiguation_cache_wikidata_ea036295a2cf3d3ab22063658bed45b926331d98.json\n",
       "{'entity_text': 'Amenhotep III', 'candidates': [{'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt'}, {'id': 'Q55018696', 'description': 'operatic character in the opera Akhnaten by Philip Glass; father of Akhenaton'}, {'id': 'Q96185335', 'description': 'Facsimile, Anen (TT 120), Amenhotep III, Queen Tiye, kiosk by Nina de Garis Davies (MET, 33.8.8)'}, {'id': 'Q96185392', 'description': 'Facsimile, Anen, TT 226, Amenhotep III, Mutemwia by Nina de Garis Davies (MET, 15.5.1)'}, {'id': 'Q97778073', 'description': 'scholarly book'}, {'id': 'Q116247775', 'description': 'head, Amenhotep III, Blue Crown at the Metropolitan Museum of Art (MET, 56.138)'}]}\n"
      ]
     }
@@ -1129,7 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1155,11 +1183,11 @@
     "def ollama_wikidata_id_selection(model, entities):\n",
     "    llm_cache = utils.read_json_file(DISAMBUGUATION_CACHE_FILE_LLM)\n",
     "    for entity in entities:\n",
-    "        if (entity[\"entity_text\"] in llm_cache and \n",
-    "            entity[\"text\"] in llm_cache[entity[\"entity_text\"]] and\n",
-    "            model in llm_cache[entity[\"entity_text\"]][entity[\"text\"]]):\n",
+    "        if (entity[\"text\"] in llm_cache and \n",
+    "            entity[\"entity_text\"] in llm_cache[entity[\"text\"]] and\n",
+    "            model in llm_cache[entity[\"text\"]][entity[\"entity_text\"]]):\n",
     "            utils.squeal(f\"Retrieving entity \\\"{entity['entity_text']}\\\" of text {entity['text_id'] + 1} from cache\")\n",
-    "            entity[\"wikidata_id\"] = llm_cache[entity[\"entity_text\"]][entity[\"text\"]][model] | {\"model\": model}\n",
+    "            entity[\"wikidata_id\"] = llm_cache[entity[\"text\"]][entity[\"entity_text\"]][model] | {\"model\": model}\n",
     "        else:\n",
     "            if \"ollama\" in sys.modules:\n",
     "                ollama = utils.importlib.import_module(\"ollama\")\n",
@@ -1170,11 +1198,11 @@
     "            prompt = make_prompt(entity[\"entity_text\"], entity[\"text\"], entity[\"candidates\"])\n",
     "            response = utils.process_text_with_ollama(model, prompt, ollama)\n",
     "            entity[\"wikidata_id\"] = process_llm_response(response, entity[\"candidates\"], model)\n",
-    "            if entity[\"entity_text\"] not in llm_cache:\n",
-    "                llm_cache[entity[\"entity_text\"]] = {}\n",
-    "            if entity[\"text\"] not in llm_cache[entity[\"entity_text\"]]:\n",
-    "                llm_cache[entity[\"entity_text\"]][entity[\"text\"]] = {}\n",
-    "            llm_cache[entity[\"entity_text\"]][entity[\"text\"]][model] = {key: value \n",
+    "            if entity[\"text\"] not in llm_cache:\n",
+    "                llm_cache[entity[\"text\"]] = {}\n",
+    "            if entity[\"entity_text\"] not in llm_cache[entity[\"text\"]]:\n",
+    "                llm_cache[entity[\"text\"]][entity[\"entity_text\"]] = {}\n",
+    "            llm_cache[entity[\"text\"]][entity[\"entity_text\"]][model] = {key: value \n",
     "                                                                       for key, value in entity[\"wikidata_id\"].items()}\n",
     "            utils.write_json_file(DISAMBUGUATION_CACHE_FILE_LLM, llm_cache)\n",
     "            time.sleep(2)\n",
@@ -1185,7 +1213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1194,8 +1222,8 @@
      "text": [
       "Retrieving entity \"Bagnani\" of text 99 from cache\n",
       "Finished processing\n",
-      "️✅ Saved data to file disambiguation_cache_llm_eef8ccc02cff1ca9d5325cbb82d0954414eed154.json\n",
-      "{'entity_text': 'Amenhotep III', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}}\n"
+      "️✅ Saved data to file disambiguation_cache_llm_78e4028165d5760d6e41e92f78e87d71b8e8d893.json\n",
+      "{'entity_text': 'Amenhotep III', 'label': 'PERSON', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 81, 'end_char': 94, 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}}\n"
      ]
     }
    ],
@@ -1206,7 +1234,7 @@
     "\n",
     "processed_entities = ollama_wikidata_id_selection(MODEL, entities[:MAX_PROCESSED_ENTITIES])\n",
     "texts_output = add_wikidata_ids_to_texts_input(texts_input[:MAX_PROCESSED], processed_entities)\n",
-    "print({key: value for key, value in processed_entities[0].items() if key in [\"entity_text\", \"text\", \"wikidata_id\"]})"
+    "print(texts_output[1][\"entities\"][0])"
    ]
   },
   {
@@ -1227,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1270,7 +1298,7 @@
    "source": [
     "for text_id, text in enumerate(texts_output):\n",
     "    if text_id < 3:\n",
-    "        display(HTML(utils.mark_entities_in_text(text[\"text_llm_output\"], text[\"entities\"])))"
+    "        display(HTML(utils.mark_entities_in_text(text[\"text_cleaned\"], text[\"entities\"])))"
    ]
   },
   {
@@ -1282,25 +1310,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "true: 1 pred: 1\n",
-      "data_format_true [[3790]]\n",
-      "data_format_pred [[3790]]\n",
-      "\u001b[1mHIPE Analysis\u001b[0m\n",
-      "╒═════════╤═══════════╤═══════════╤════════════╕\n",
-      "│ Label   │   P_micro │   R_micro │   F1_micro │\n",
-      "╞═════════╪═══════════╪═══════════╪════════════╡\n",
-      "│ ALL     │      70.6 │      83.5 │       76.5 │\n",
-      "╘═════════╧═══════════╧═══════════╧════════════╛\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ED_ANNOTATIONS_FILE = \"disambiguation_gold.json\"\n",
     "\n",
@@ -1310,7 +1322,37 @@
     "machine_entities = utils.add_char_offsets_to_processed_entities(processed_entities)\n",
     "text_tokens_machine = utils.add_gold_linking_entities_to_text_tokens(copy.deepcopy(text_tokens), machine_entities)\n",
     "\n",
-    "utils.evaluate_linking(text_tokens_gold, text_tokens_machine, clef_evaluation)"
+    "# utils.hipe_evaluate_linking(text_tokens_gold, text_tokens_machine, clef_evaluation, \"wikidata_id\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The HIPE-scorer produces very optimistic scores. Therefore we evaluate the disambiguation task with a local evaluation function: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒═════════╤═════════════╤══════════╤══════╕\n",
+      "│ Label   │   Precision │   Recall │   F1 │\n",
+      "╞═════════╪═════════════╪══════════╪══════╡\n",
+      "│ ALL     │        51.2 │     47.5 │ 49.3 │\n",
+      "╘═════════╧═════════════╧══════════╧══════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_entities = utils.get_entities_from_token_lists(text_tokens_gold, \"gold_tag\")\n",
+    "machine_entities = utils.get_entities_from_token_lists(text_tokens_machine, \"machine_tag\")\n",
+    "correct, missed, wrong = utils.evaluate(gold_entities, machine_entities, \"wikidata_id\")"
    ]
   },
   {
@@ -1373,19 +1415,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These two helper functions are needed in different sections, we define them here."
+    "The next two helper functions are needed in different sections, we define them here."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LINK_TYPES = { \n",
+    "    1: \"the entity is a person depicted on or by the artefact\",\n",
+    "    2: \"the entity is a person that created the artefact\",\n",
+    "    3: \"the entity is a person that discovered the artefact\",\n",
+    "    4: \"the entity is a person that owned the artefact\",\n",
+    "    5: \"the entity is a person in power during the period of the creation of the artefact\",\n",
+    "    6: \"the entity is a location depicted on or by the artefact\",\n",
+    "    7: \"the entity is a location where the artefact was created\",\n",
+    "    8: \"the entity is a location where the artefact was produced\",\n",
+    "    9: \"the entity is a location where the artefact was discovered\",\n",
+    "    10: \"the entity is the artefact's current location\",\n",
+    "    11: \"other entity type or other relation between entity and artefact\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
     "CONTEXT = \"\"\"extracted from records of objects in the collection of \n",
     "             the Egyptian museum, Torino, the Museo Egizio – Torino\"\"\"\n",
     "\n",
-    "def make_linking_prompt(entity, text):\n",
+    "def make_linking_prompt(text, entity_text):\n",
     "    \"\"\"Create an LLM prompt, given a text and target labels and return it\"\"\"\n",
     "    return f\"\"\"\n",
     "Considering the following description of a museum artefact {CONTEXT}:\n",
@@ -1395,7 +1458,7 @@
     "Retrieve the relationship between this artefact and the following named entity, \n",
     "mentioned in the description:\n",
     "\n",
-    "{entity}\n",
+    "{entity_text}\n",
     "\n",
     "Please answer the following question: Why is this entity mentioned in the description? \n",
     "Please select your answer from the following options:\n",
@@ -1418,7 +1481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1431,8 +1494,8 @@
     "        entities_per_text[entity[\"text_id\"]][entity[\"entity_text\"]] = entity\n",
     "    for text_id, text in enumerate(texts_input):\n",
     "        for entity in text[\"entities\"]:\n",
-    "            if text_id in entities_per_text and entity[\"text\"] in entities_per_text[text_id]:\n",
-    "                entity[\"link\"] = entities_per_text[text_id][entity[\"text\"]][\"link\"]\n",
+    "            if text_id in entities_per_text and entity[\"entity_text\"] in entities_per_text[text_id]:\n",
+    "                entity[\"link_id\"] = entities_per_text[text_id][entity[\"entity_text\"]][\"link_id\"]\n",
     "    return texts_input"
    ]
   },
@@ -1447,14 +1510,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'text_cleaned': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'entities': [{'text': 'Amenhotep III', 'label': 'PERSON', 'start_char': 81, 'end_char': 94, 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}}, {'text': 'Thebes', 'label': 'LOCATION', 'start_char': 111, 'end_char': 117, 'wikidata_id': {'id': 'Q101583', 'description': 'ancient Egyptian city', 'model': 'qwen3:8b'}}, {'text': 'Drovetti', 'label': 'PERSON', 'start_char': 120, 'end_char': 128, 'wikidata_id': {'id': 'Q822895', 'description': 'Italian diplomat, explorer and scholar', 'model': 'qwen3:8b'}}]}\n"
+      "{'text_cleaned': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'entities': [{'entity_text': 'Amenhotep III', 'label': 'PERSON', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 81, 'end_char': 94, 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}}, {'entity_text': 'Thebes', 'label': 'LOCATION', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 111, 'end_char': 117, 'wikidata_id': {'id': 'Q101583', 'description': 'ancient Egyptian city', 'model': 'qwen3:8b'}}, {'entity_text': 'Drovetti', 'label': 'PERSON', 'text': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'text_id': 1, 'start_char': 120, 'end_char': 128, 'wikidata_id': {'id': 'Q822895', 'description': 'Italian diplomat, explorer and scholar', 'model': 'qwen3:8b'}}]}\n"
      ]
     }
    ],
@@ -1482,7 +1545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1493,12 +1556,14 @@
     "    entities = utils.extract_entities_from_ner_input(texts_input)\n",
     "    linking_cache = utils.read_json_file(LINKING_CACHE_FILE)\n",
     "    for entity in entities:\n",
-    "        if (entity[\"entity_text\"] in linking_cache and \n",
-    "            entity[\"text\"] in linking_cache[entity[\"entity_text\"]] and\n",
-    "            model in linking_cache[entity[\"entity_text\"]][entity[\"text\"]]):\n",
+    "        if (entity[\"text\"] in linking_cache and \n",
+    "            entity[\"entity_text\"] in linking_cache[entity[\"text\"]] and\n",
+    "            model in linking_cache[entity[\"text\"]][entity[\"entity_text\"]]):\n",
     "            utils.squeal(f\"Retrieving entity \\\"{entity['entity_text']}\\\" of text {entity['text_id'] + 1} from cache\")\n",
-    "            if \"link\" not in entity: entity[\"link\"] = {}\n",
-    "            entity[\"link\"][model] = linking_cache[entity[\"entity_text\"]][entity[\"text\"]][model]\n",
+    "            link_id = int(regex.sub(r\"\\D* .*\", \"\", linking_cache[entity[\"text\"]][entity[\"entity_text\"]][model]))\n",
+    "            entity[\"link_id\"] = {\"id\": link_id,\n",
+    "                                 \"description\": LINK_TYPES[link_id] if link_id in LINK_TYPES else \"\",\n",
+    "                                 \"model\": model}\n",
     "        else:\n",
     "            utils.squeal(f\"Sending entity \\\"{entity['entity_text']}\\\" of text {entity['text_id'] + 1} to {model}\")\n",
     "            if \"ollama\" in sys.modules:\n",
@@ -1506,14 +1571,16 @@
     "            else:\n",
     "                ollama = utils.import_ollama_module()\n",
     "            utils.install_ollama_model(model, ollama)\n",
-    "            prompt = make_linking_prompt(entity[\"entity_text\"], entity[\"text\"])\n",
-    "            if \"link\" not in entity: entity[\"link\"] = {}\n",
-    "            entity[\"link\"][model] = utils.process_text_with_ollama(model, prompt, ollama)\n",
-    "            if entity[\"entity_text\"] not in linking_cache:\n",
-    "                linking_cache[entity[\"entity_text\"]] = {}\n",
-    "            if entity[\"text\"] not in linking_cache[entity[\"entity_text\"]]:\n",
-    "                linking_cache[entity[\"entity_text\"]][entity[\"text\"]] = {}\n",
-    "            linking_cache[entity[\"entity_text\"]][entity[\"text\"]][model] = entity[\"link\"][model]\n",
+    "            prompt = make_linking_prompt(entity[\"text\"], entity[\"entity_text\"])\n",
+    "            link_id = int(regex.sub(\" .*$\", \"\", utils.process_text_with_ollama(model, prompt, ollama)))\n",
+    "            entity[\"link_id\"] = {\"id\": link_id,\n",
+    "                                 \"description\": LINK_TYPES[link_id] if link_id in LINK_TYPES else \"\",\n",
+    "                                 \"model\": model}\n",
+    "            if entity[\"text\"] not in linking_cache:\n",
+    "                linking_cache[entity[\"text\"]] = {}\n",
+    "            if entity[\"entity_text\"] not in linking_cache[entity[\"text\"]]:\n",
+    "                linking_cache[entity[\"text\"]][entity[\"entity_text\"]] = {}\n",
+    "            linking_cache[entity[\"text\"]][entity[\"entity_text\"]][model] = entity[\"link_id\"][model]\n",
     "            utils.write_json_file(LINKING_CACHE_FILE, linking_cache)\n",
     "    print(\"Finished processing\")\n",
     "    utils.save_data_to_json_file(linking_cache, file_name=LINKING_CACHE_FILE, in_colab=in_colab)\n",
@@ -1536,23 +1603,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Retrieving entity \"Drovetti\" of text 10 from cache\n",
+      "Retrieving entity \"Bagnani\" of text 99 from cache\n",
       "Finished processing\n",
-      "️✅ Saved data to file linking_cache_042f78afe60166f77441416d4eef052792ed3028.json\n",
-      "{'text_cleaned': 'Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115', 'entities': [{'entity_text': 'Amenhotep III', 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}, 'link': '5'}, {'entity_text': 'Thebes', 'wikidata_id': {'id': 'Q101583', 'description': 'ancient Egyptian city', 'model': 'qwen3:8b'}, 'link': '7'}, {'entity_text': 'Drovetti', 'wikidata_id': {'id': 'Q822895', 'description': 'Italian diplomat, explorer and scholar', 'model': 'qwen3:8b'}, 'link': '4'}]}\n"
+      "️✅ Saved data to file linking_cache_3d1c7c4803416a739beafbe6ec7374cfd2129440.json\n",
+      "{'text_cleaned': 'Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256', 'entities': [{'entity_text': 'Amenhotep III', 'wikidata_id': {'id': 'Q42606', 'description': 'ninth Pharaoh of the Eighteenth dynasty of Egypt', 'model': 'qwen3:8b'}, 'link_id': {'id': 5, 'description': 'the entity is a person in power during the period of the creation of the artefact', 'model': 'qwen3:8b'}}, {'entity_text': 'Thebes', 'wikidata_id': {'id': 'Q101583', 'description': 'ancient Egyptian city', 'model': 'qwen3:8b'}, 'link_id': {'id': 7, 'description': 'the entity is a location where the artefact was created', 'model': 'qwen3:8b'}}, {'entity_text': 'Drovetti', 'wikidata_id': {'id': 'Q822895', 'description': 'Italian diplomat, explorer and scholar', 'model': 'qwen3:8b'}, 'link_id': {'id': 4, 'description': 'the entity is a person that owned the artefact', 'model': 'qwen3:8b'}}]}\n"
      ]
     }
    ],
    "source": [
     "model = \"qwen3:8b\"\n",
-    "MAX_PROCESSED = 10\n",
+    "MAX_PROCESSED = len(texts_input)\n",
     "\n",
     "processed_entities = ollama_link_suggestion(model, texts_input[:MAX_PROCESSED])\n",
     "texts_output = add_linking_data_to_texts_input(texts_input[:MAX_PROCESSED], processed_entities)\n",
-    "print({\"text_cleaned\": texts_output[0][\"text_cleaned\"],\n",
-    "       \"entities\": [{\"entity_text\": entity[\"text\"], \n",
+    "print({\"text_cleaned\": texts_output[1][\"text_cleaned\"],\n",
+    "       \"entities\": [{\"entity_text\": entity[\"entity_text\"], \n",
     "                     \"wikidata_id\": entity[\"wikidata_id\"], \n",
-    "                     \"link\": list(entity[\"link\"].values())[0]} for entity in texts_output[1][\"entities\"]]})"
+    "                     \"link_id\": entity[\"link_id\"]} for entity in texts_output[1][\"entities\"]]})"
    ]
   },
   {
@@ -1578,7 +1645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1596,7 +1663,7 @@
     {
      "data": {
       "text/html": [
-       "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of <span style=\"border: 1px solid black; color: red;\">Amenhotep III</span><sup>Q42606,5</sup> (1390-1353 BC). <span style=\"border: 1px solid black; color: green;\">Thebes</span><sup>Q101583,7</sup>.. <span style=\"border: 1px solid black; color: red;\">Drovetti</span><sup>Q822895,4</sup> collection (1824). C. 256"
+       "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of <span style=\"border: 1px solid black; color: red;\">Amenhotep III</span><sup>Q42606</sup> (1390-1353 BC). <span style=\"border: 1px solid black; color: green;\">Thebes</span><sup>Q101583</sup>.. <span style=\"border: 1px solid black; color: red;\">Drovetti</span><sup>Q822895</sup> collection (1824). C. 256"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1608,7 +1675,31 @@
     {
      "data": {
       "text/html": [
-       "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. <span style=\"border: 1px solid black; color: red;\">Drovetti</span><sup>Q822895,4</sup> collection (1824). C. 271"
+       "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. <span style=\"border: 1px solid black; color: red;\">Drovetti</span><sup>Q822895</sup> collection (1824). C. 271"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Amulet depicting the god <span style=\"border: 1px solid black; color: red;\">Harpocrates</span><sup>Q787492</sup>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. <span style=\"border: 1px solid black; color: red;\">Drovetti</span><sup>Q822895</sup> collection (1824). C. 515"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1620,8 +1711,320 @@
    ],
    "source": [
     "for text_id, text in enumerate(texts_output):\n",
-    "    if text_id < 3:\n",
-    "        display(HTML(utils.mark_entities_in_text(text[\"text_llm_output\"], text[\"entities\"], linking_model=model)))"
+    "    if text_id < 5:\n",
+    "        display(HTML(utils.mark_entities_in_text(text[\"text_cleaned\"], text[\"entities\"], linking_model=model)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.5 Evaluate linking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def group_entities_by_sentence(entity_list, nbr_of_sentences=100):\n",
+    "    \"\"\"Convert entities list to list of lists of entities per sentence\"\"\"\n",
+    "    sentence_list = nbr_of_sentences * []\n",
+    "    for entity in entity_list:\n",
+    "        while len(sentence_list) <= entity[\"text_id\"]:\n",
+    "            sentence_list.append([])\n",
+    "        sentence_list[entity[\"text_id\"]].append(entity)\n",
+    "    return sentence_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gold_entities = utils.read_json_file(ED_ANNOTATIONS_FILE)\n",
+    "text_tokens_gold = utils.add_gold_linking_entities_to_text_tokens(copy.deepcopy(text_tokens), gold_entities)\n",
+    "\n",
+    "text_tokens_machine = utils.add_gold_linking_entities_to_text_tokens(copy.deepcopy(text_tokens), \n",
+    "                                                                     group_entities_by_sentence(processed_entities))\n",
+    "\n",
+    "#utils.hipe_evaluate_linking(text_tokens_gold, text_tokens_machine, clef_evaluation, \"link_id\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The HIPE-scorer produces very optimistic scores. Therefore we evaluate the linking task with a local evaluation function: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒═════════╤═════════════╤══════════╤══════╕\n",
+      "│ Label   │   Precision │   Recall │   F1 │\n",
+      "╞═════════╪═════════════╪══════════╪══════╡\n",
+      "│ ALL     │          74 │     68.7 │ 71.2 │\n",
+      "╘═════════╧═════════════╧══════════╧══════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_entities = utils.get_entities_from_token_lists(text_tokens_gold, \"gold_tag\")\n",
+    "machine_entities = utils.get_entities_from_token_lists(text_tokens_machine, \"machine_tag\")\n",
+    "correct, missed, wrong = utils.evaluate(gold_entities, machine_entities, \"link_id\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.7 Evaluation code test\n",
+    "\n",
+    "We test the two versions of the evaluation code (HIPE-scorer and local) with a sentence with three named entities. The machine model recognizes two entities correctly (New York and Mary: True Positives = 2), misses one (John Carter Smith: False Negatives = 1) and identifies one entities which is wrong (lives: False Positives = 1). The expected scores for the Recognition are: Precision = Recall = F1 = 66.7%.\n",
+    "\n",
+    "In the Linking task, the machine model gets one link correct (New York: True Positives = 1), misses two links (John Carter Smith and Mary: False Negatives = 2) and generates two incorrect links (lives and Mary: False Positives = 2). The expected scores for the Linking task are: Precision = Recall = F1 = 33.3%. The linking scores generated by the HIPE-scorer are incorrect. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_tokens_gold = [[{\"entity_text\": \"John\",\n",
+    "                      \"start_char\": 0,\n",
+    "                      \"end_char\": 4,\n",
+    "                      \"gold_tag\": \"B-PERSON\",\n",
+    "                      \"link_id\": 1},\n",
+    "                     {\"entity_text\": \"Carter\",\n",
+    "                      \"start_char\": 5,\n",
+    "                      \"end_char\": 11,\n",
+    "                      \"gold_tag\": \"I-PERSON\",\n",
+    "                      \"link_id\": 1},\n",
+    "                     {\"entity_text\": \"Smith\",\n",
+    "                      \"start_char\": 12,\n",
+    "                      \"end_char\": 17,\n",
+    "                      \"gold_tag\": \"I-PERSON\",\n",
+    "                      \"link_id\": 1},\n",
+    "                     {\"entity_text\": \"lives\",\n",
+    "                      \"start_char\": 18,\n",
+    "                      \"end_char\": 23,\n",
+    "                      \"gold_tag\": \"O\",\n",
+    "                      \"link_id\": \"_\"},\n",
+    "                     {\"entity_text\": \"in\",\n",
+    "                      \"start_char\": 24,\n",
+    "                      \"end_char\": 26,\n",
+    "                      \"gold_tag\": \"O\",\n",
+    "                      \"link_id\": \"_\"},\n",
+    "                     {\"entity_text\": \"New\",\n",
+    "                      \"start_char\": 27,\n",
+    "                      \"end_char\": 30,\n",
+    "                      \"gold_tag\": \"B-LOCATION\",\n",
+    "                      \"link_id\": 9},\n",
+    "                     {\"entity_text\": \"York\",\n",
+    "                      \"start_char\": 31,\n",
+    "                      \"end_char\": 35,\n",
+    "                      \"gold_tag\": \"I-LOCATION\",\n",
+    "                      \"link_id\": 9},\n",
+    "                     {\"entity_text\": \"with\",\n",
+    "                      \"start_char\": 36,\n",
+    "                      \"end_char\": 40,\n",
+    "                      \"gold_tag\": \"O\",\n",
+    "                      \"link_id\": \"_\"},\n",
+    "                     {\"entity_text\": \"Mary\",\n",
+    "                      \"start_char\": 41,\n",
+    "                      \"end_char\": 41,\n",
+    "                      \"gold_tag\": \"B-PERSON\",\n",
+    "                      \"link_id\": 3}]]\n",
+    "for token in text_tokens_gold[0]:\n",
+    "    token[\"sent_id\"] = 0\n",
+    "    token[\"text_id\"] = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_tokens_machine = [[{\"entity_text\": \"John\",\n",
+    "                         \"start_char\": 0,\n",
+    "                         \"end_char\": 4,\n",
+    "                         \"gold_tag\": \"B-PERSON\",\n",
+    "                         \"machine_tag\": \"O\",\n",
+    "                         \"link_id\": \"_\"},\n",
+    "                        {\"entity_text\": \"Carter\",\n",
+    "                         \"start_char\": 5,\n",
+    "                         \"end_char\": 11,\n",
+    "                         \"gold_tag\": \"I-PERSON\",\n",
+    "                         \"machine_tag\": \"O\",\n",
+    "                         \"link_id\": \"_\"},\n",
+    "                        {\"entity_text\": \"Smith\",\n",
+    "                         \"start_char\": 12,\n",
+    "                         \"end_char\": 17,\n",
+    "                         \"gold_tag\": \"I-PERSON\",\n",
+    "                         \"machine_tag\": \"O\",\n",
+    "                         \"link_id\": \"_\"},\n",
+    "                        {\"entity_text\": \"lives\",\n",
+    "                         \"start_char\": 18,\n",
+    "                         \"end_char\": 23,\n",
+    "                         \"gold_tag\": \"O\",\n",
+    "                         \"machine_tag\": \"B-LOCATION\",\n",
+    "                         \"link_id\": 9},\n",
+    "                        {\"entity_text\": \"in\",\n",
+    "                         \"start_char\": 24,\n",
+    "                         \"end_char\": 26,\n",
+    "                         \"gold_tag\": \"O\",\n",
+    "                         \"machine_tag\": \"O\",\n",
+    "                         \"link_id\": \"_\"},\n",
+    "                        {\"entity_text\": \"New\",\n",
+    "                         \"start_char\": 27,\n",
+    "                         \"end_char\": 30,\n",
+    "                         \"gold_tag\": \"B-LOCATION\",\n",
+    "                         \"machine_tag\": \"B-LOCATION\",\n",
+    "                         \"link_id\": 9},\n",
+    "                        {\"entity_text\": \"York\",\n",
+    "                         \"start_char\": 31,\n",
+    "                         \"end_char\": 35,\n",
+    "                         \"gold_tag\": \"I-LOCATION\",\n",
+    "                         \"machine_tag\": \"I-LOCATION\",\n",
+    "                         \"link_id\": 9},\n",
+    "                        {\"entity_text\": \"with\",\n",
+    "                         \"start_char\": 36,\n",
+    "                         \"end_char\": 40,\n",
+    "                         \"gold_tag\": \"O\",\n",
+    "                         \"machine_tag\": \"O\",\n",
+    "                         \"link_id\": \"_\"},\n",
+    "                        {\"entity_text\": \"Mary\",\n",
+    "                         \"start_char\": 41,\n",
+    "                         \"end_char\": 41,\n",
+    "                         \"gold_tag\": \"B-PERSON\",\n",
+    "                         \"machine_tag\": \"B-PERSON\",\n",
+    "                         \"link_id\": 1}]]\n",
+    "for token in text_tokens_machine[0]:\n",
+    "    token[\"sent_id\"] = 0\n",
+    "    token[\"text_id\"] = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "true: 1 pred: 1\n",
+      "data_format_true [[10]]\n",
+      "data_format_pred [[10]]\n",
+      "\u001b[1mHIPE Analysis\u001b[0m\n",
+      "╒══════════╤═══════════╤═══════════╤════════════╕\n",
+      "│ Label    │   P_micro │   R_micro │   F1_micro │\n",
+      "╞══════════╪═══════════╪═══════════╪════════════╡\n",
+      "│ PERSON   │     100   │      50   │       66.7 │\n",
+      "├──────────┼───────────┼───────────┼────────────┤\n",
+      "│ LOCATION │      50   │     100   │       66.7 │\n",
+      "├──────────┼───────────┼───────────┼────────────┤\n",
+      "│ ALL      │      66.7 │      66.7 │       66.7 │\n",
+      "╘══════════╧═══════════╧═══════════╧════════════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "utils.hipe_evaluate(text_tokens_machine, clef_evaluation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒═════════╤═════════════╤══════════╤══════╕\n",
+      "│ Label   │   Precision │   Recall │   F1 │\n",
+      "╞═════════╪═════════════╪══════════╪══════╡\n",
+      "│ ALL     │        66.7 │     66.7 │ 66.7 │\n",
+      "╘═════════╧═════════════╧══════════╧══════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_entities = utils.get_entities_from_token_lists(text_tokens_gold, \"gold_tag\")\n",
+    "machine_entities = utils.get_entities_from_token_lists(text_tokens_machine, \"machine_tag\")\n",
+    "correct, missed, wrong = utils.evaluate(gold_entities, machine_entities, \"gold_tag\", \"machine_tag\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "true: 1 pred: 1\n",
+      "data_format_true [[10]]\n",
+      "data_format_pred [[10]]\n",
+      "\u001b[1mHIPE Analysis\u001b[0m\n",
+      "╒═════════╤═══════════╤═══════════╤════════════╕\n",
+      "│ Label   │   P_micro │   R_micro │   F1_micro │\n",
+      "╞═════════╪═══════════╪═══════════╪════════════╡\n",
+      "│ ALL     │      66.7 │      66.7 │       66.7 │\n",
+      "├─────────┼───────────┼───────────┼────────────┤\n",
+      "│ 9       │      50   │     100   │       66.7 │\n",
+      "├─────────┼───────────┼───────────┼────────────┤\n",
+      "│ 3       │     100   │     100   │      100   │\n",
+      "├─────────┼───────────┼───────────┼────────────┤\n",
+      "│ 1       │       0   │       0   │        0   │\n",
+      "╘═════════╧═══════════╧═══════════╧════════════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "utils.hipe_evaluate_linking(text_tokens_gold, text_tokens_machine, clef_evaluation, \"link_id\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒═════════╤═════════════╤══════════╤══════╕\n",
+      "│ Label   │   Precision │   Recall │   F1 │\n",
+      "╞═════════╪═════════════╪══════════╪══════╡\n",
+      "│ ALL     │        33.3 │     33.3 │ 33.3 │\n",
+      "├─────────┼─────────────┼──────────┼──────┤\n",
+      "│ 9       │        50   │    100   │ 66.7 │\n",
+      "├─────────┼─────────────┼──────────┼──────┤\n",
+      "│ 3       │         0   │      0   │  0   │\n",
+      "├─────────┼─────────────┼──────────┼──────┤\n",
+      "│ 1       │         0   │      0   │  0   │\n",
+      "╘═════════╧═════════════╧══════════╧══════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_entities = utils.get_entities_from_token_lists(text_tokens_gold, \"gold_tag\")\n",
+    "machine_entities = utils.get_entities_from_token_lists(text_tokens_machine, \"machine_tag\")\n",
+    "correct, missed, wrong = utils.evaluate(gold_entities, machine_entities, \"link_id\", \"link_id\", [\"ALL\", \"9\", \"3\", \"1\"])"
    ]
   },
   {

--- a/notebooks/tasks/disambiguation_cache_llm.json
+++ b/notebooks/tasks/disambiguation_cache_llm.json
@@ -1,14 +1,12 @@
 {
-  "Sekhmet": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+  "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+    "Sekhmet": {
       "gpt-4o-mini": {
         "id": "Q146104",
         "description": "Egyptian deity"
       }
-    }
-  },
-  "Thebes": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+    },
+    "Thebes": {
       "gpt-4o-mini": {
         "id": "Q101583",
         "description": "ancient Egyptian city"
@@ -19,190 +17,996 @@
         "model": "qwen3:8b"
       }
     },
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
+    "Amenhotep III": {
       "gpt-4o-mini": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city"
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
       },
       "qwen3:8b": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city",
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
         "model": "qwen3:8b"
       }
     },
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city"
-      },
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city",
-        "model": "qwen3:8b"
-      }
-    },
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "gpt-4o-mini": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city"
-      },
-      "qwen3:8b": {
-        "id": "Q101583",
-        "description": "ancient Egyptian city",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
     }
   },
-  "Amenhotep III": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+  "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
+    "Thebes": {
       "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+        "id": "Q101583",
+        "description": "ancient Egyptian city"
       },
       "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "id": "Q101583",
+        "description": "ancient Egyptian city",
         "model": "qwen3:8b"
       }
     },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
     },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
+    "Book of the Dead of Aaner": {
       "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
+        "id": "Q117398410",
+        "description": "papyurs of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1771)"
       }
     },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
+    "Mut": {
       "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
+        "id": "[]",
+        "description": "papyurs of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1771)"
       }
     },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
+    "Cyperus": {
       "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
+        "id": "Q161224",
+        "description": "genus of plants"
       }
     },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
+    "Aaner": {
       "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "id": "Q37470770",
+        "description": "family name",
         "model": "qwen3:8b"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
       }
     }
   },
-  "Bastet": {
-    "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
+  "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
+    "Thebes": {
+      "gpt-4o-mini": {
+        "id": "Q101583",
+        "description": "ancient Egyptian city"
+      },
+      "qwen3:8b": {
+        "id": "Q101583",
+        "description": "ancient Egyptian city",
+        "model": "qwen3:8b"
+      }
+    },
+    "Book of the Dead of Iuefankh": {
+      "gpt-4o-mini": {
+        "id": "Q117398419",
+        "description": "papyurs of the Egyptian Hellenistic period, 332–30 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1791)"
+      }
+    },
+    "Cyperus papyrus": {
+      "gpt-4o-mini": {
+        "id": "Q158808",
+        "description": "species of aquatic flowering plant"
+      }
+    },
+    "Ptolemaic period": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "species of aquatic flowering plant"
+      }
+    },
+    "Drovetti collection": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "ancient Egyptian city"
+      }
+    },
+    "Iuefankh": {
+      "qwen3:8b": {
+        "id": "Q125422532",
+        "description": "antico egizio",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
+    "Thebes": {
+      "gpt-4o-mini": {
+        "id": "Q101583",
+        "description": "ancient Egyptian city"
+      },
+      "qwen3:8b": {
+        "id": "Q101583",
+        "description": "ancient Egyptian city",
+        "model": "qwen3:8b"
+      }
+    },
+    "Drovetti": {
+      "qwen3:8b": {
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tamutmutef": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "ancient Egyptian city"
+      }
+    },
+    "Coffin of Tamutmutef": {
+      "qwen3:8b": {
+        "id": "Q134774234",
+        "description": "wooden sarcophagus of the Twenty–first – Twenty–second Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–746 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.2228/01)",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "qwen3:8b": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "18th Dynasty": {
+      "qwen3:8b": {
+        "id": "Q146055",
+        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut",
+        "model": "qwen3:8b"
+      }
+    },
+    "Bread loaf": {
+      "qwen3:8b": {
+        "id": "Q134774562",
+        "description": "bread of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8278)",
+        "model": "qwen3:8b"
+      }
+    },
+    "Vegetable organic remains": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomb of Kha": {
+      "qwen3:8b": {
+        "id": "Q648960",
+        "description": "ancient Egyptian tomb in the Valley of the Queens",
+        "model": "qwen3:8b"
+      }
+    },
+    "S. 8273": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Bowl": {
+      "gpt-4o-mini": {
+        "id": "Q153988",
+        "description": "circular, open-top container frequently used as tableware"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      },
+      "qwen3:8b": {
+        "id": "Q16277895",
+        "description": "male given name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q2234103",
+        "description": "lunar crater"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      }
+    },
+    "Persea": {
+      "gpt-4o-mini": {
+        "id": "Q132039",
+        "description": "genus of plants"
+      }
+    },
+    "papyrus": {
+      "gpt-4o-mini": {
+        "id": "Q158808",
+        "description": "species of aquatic flowering plant"
+      }
+    }
+  },
+  "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q617030",
+        "description": "crater on Mars"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      }
+    },
+    "papyrus": {
+      "gpt-4o-mini": {
+        "id": "Q125576",
+        "description": "writing and painting material"
+      }
+    },
+    "Pestle": {
+      "gpt-4o-mini": {
+        "id": "Q907209",
+        "description": "Blunt tool to grind things in a mortar"
+      }
+    }
+  },
+  "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q2234103",
+        "description": "lunar crater"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "qwen3:8b": {
+        "id": "Q16277895",
+        "description": "male given name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q2234103",
+        "description": "lunar crater"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      },
+      "qwen3:8b": {
+        "id": "Q2740671",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "18th Dynasty": {
+      "gpt-4o-mini": {
+        "id": "Q146055",
+        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut"
+      }
+    }
+  },
+  "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q617030",
+        "description": "crater on Mars"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      },
+      "qwen3:8b": {
+        "id": "Q16277895",
+        "description": "male given name",
+        "model": "qwen3:8b"
+      }
+    },
+    "18th Dynasty": {
+      "gpt-4o-mini": {
+        "id": "Q146055",
+        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut"
+      }
+    },
+    "Lidded basket": {
+      "gpt-4o-mini": {
+        "id": "Q117429170",
+        "description": "plant fiber basket of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8414)"
+      }
+    },
+    "juniper berries": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "plant fiber basket of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8414)"
+      }
+    },
+    "Vegetable fibers": {
+      "gpt-4o-mini": {
+        "id": "Q117233367",
+        "description": "plant fibers of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy"
+      }
+    }
+  },
+  "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q16277895",
+        "description": "male given name"
+      },
+      "qwen3:8b": {
+        "id": "Q16277895",
+        "description": "male given name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "gpt-4o-mini": {
+        "id": "Q2740671",
+        "description": "family name"
+      }
+    },
+    "Tunic": {
+      "gpt-4o-mini": {
+        "id": "Q201714",
+        "description": "simple T-shaped or sleeveless garment, usually unfitted, of archaic origin"
+      }
+    }
+  },
+  "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kha": {
+      "qwen3:8b": {
+        "id": "Q16277895",
+        "description": "male given name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Kohl tube": {
+      "gpt-4o-mini": {
+        "id": "Q116273799",
+        "description": "kohl tube, papyrus column at the Metropolitan Museum of Art (MET, 91.1.1351)"
+      }
+    }
+  },
+  "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
+    "Amenhotep III": {
+      "gpt-4o-mini": {
+        "id": "Q42606",
+        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
+      }
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      }
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": {
+        "id": "Q158052",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      }
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": {
+        "id": "Q157985",
+        "description": "Egyptian Pharaoh of the 18th dynasty"
+      }
+    }
+  },
+  "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
+    "Bastet": {
       "gpt-4o-mini": {
         "id": "Q129106",
         "description": "Egyptian cat deity"
       }
-    }
-  },
-  "Drovetti": {
-    "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
+    },
+    "Drovetti": {
       "gpt-4o-mini": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
@@ -215,8 +1019,10 @@
         "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
-    },
-    "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
+    }
+  },
+  "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
+    "Drovetti": {
       "gpt-4o-mini": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
@@ -227,7 +1033,15 @@
         "model": "qwen3:8b"
       }
     },
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
+    "Apis": {
+      "gpt-4o-mini": {
+        "id": "None",
+        "description": "Egyptian sky deity"
+      }
+    }
+  },
+  "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
+    "Drovetti": {
       "gpt-4o-mini": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
@@ -238,138 +1052,59 @@
         "model": "qwen3:8b"
       }
     },
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    },
-    "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
-      "qwen3:8b": {
-        "id": "Q822895",
-        "description": "Italian diplomat, explorer and scholar",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Harpocrates": {
-    "Amulet depicting the god Harpocrates": {
+    "Tuthmosis III": {
       "gpt-4o-mini": {
-        "id": "Q787492",
-        "description": "God-child in Egyptian mythology"
+        "id": "Q157899",
+        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
       },
       "qwen3:8b": {
-        "id": "Q787492",
-        "description": "God-child in Egyptian mythology",
+        "id": "Q157899",
+        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty",
         "model": "qwen3:8b"
+      }
+    },
+    "Djehuty": {
+      "gpt-4o-mini": {
+        "id": "Q912046",
+        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\""
+      },
+      "qwen3:8b": {
+        "id": "Q912046",
+        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\"",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tuthmosi III": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\""
       }
     }
   },
-  "Satet": {
-    "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
+  "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
+    "Drovetti": {
+      "qwen3:8b": {
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
+        "model": "qwen3:8b"
+      }
+    },
+    "Satet": {
       "gpt-4o-mini": {
         "id": "Q843206",
         "description": "ancient Egyptian goddess"
       }
     }
   },
-  "Statue": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": {
-        "id": "Q179700",
-        "description": "sculpture primarily conceived as a representational figure"
-      }
-    }
-  },
-  "Bes": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": {
-        "id": "Q37776",
-        "description": "commune in Doubs, France"
-      }
-    }
-  },
-  "Ptolemaic": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": {
-        "id": "Q2320005",
-        "description": "Hellenistic kingdom in ancient Egypt from 305 to 30 BC"
-      }
-    }
-  },
-  "Roman": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": {
-        "id": "Q218",
-        "description": "country in Southeast Europe"
+  "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
+    "Drovetti": {
+      "qwen3:8b": {
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
+        "model": "qwen3:8b"
       }
     },
-    "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
-      "gpt-4o-mini": {
-        "id": "Q218",
-        "description": "country in Southeast Europe"
-      }
-    }
-  },
-  "Horus": {
-    "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
+    "Horus": {
       "gpt-4o-mini": {
         "id": "Q84122",
         "description": "Egyptian sky deity"
@@ -381,24 +1116,15 @@
       }
     }
   },
-  "Apis": {
-    "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
-      "gpt-4o-mini": {
-        "id": "None",
-        "description": "Egyptian sky deity"
+  "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
+    "Drovetti": {
+      "qwen3:8b": {
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
+        "model": "qwen3:8b"
       }
-    }
-  },
-  "wedjat-eye": {
-    "Amulet depicting the wedjat-eye": {
-      "gpt-4o-mini": {
-        "id": "Q116419933",
-        "description": "amulet, Wedjat eye at the Metropolitan Museum of Art (MET, O.C.2887)"
-      }
-    }
-  },
-  "Amenhotep I": {
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
+    },
+    "Amenhotep I": {
       "gpt-4o-mini": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
@@ -408,258 +1134,8 @@
         "description": "second Pharaoh of the Eighteenth dynasty of Egypt",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Deir el-Medina": {
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
     },
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      }
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965": {
-      "gpt-4o-mini": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings"
-      },
-      "qwen3:8b": {
-        "id": "Q750212",
-        "description": "ancient Egyptian village in the Valley of the Kings",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
@@ -671,66 +1147,26 @@
       }
     }
   },
-  "Ramesses II": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "gpt-4o-mini": {
-        "id": "Q1523",
-        "description": "Egyptian third pharaoh of the Nineteenth Dynasty"
-      },
+  "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q1523",
-        "description": "Egyptian third pharaoh of the Nineteenth Dynasty",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Re": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "gpt-4o-mini": {
-        "id": "Q20148490",
-        "description": "family name"
-      }
-    }
-  },
-  "Heliopolis": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "gpt-4o-mini": {
-        "id": "Q191687",
-        "description": "city of ancient Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q191687",
-        "description": "city of ancient Egypt",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
     },
-    "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q191687",
-        "description": "city of ancient Egypt"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "Q191687",
-        "description": "city of ancient Egypt",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Abydos": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "gpt-4o-mini": {
-        "id": "Q192268",
-        "description": "city in ancient Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q192268",
-        "description": "city in ancient Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Huy": {
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
+    },
+    "Huy": {
       "gpt-4o-mini": {
         "id": "Q110831390",
         "description": "male given name"
@@ -740,241 +1176,29 @@
         "description": "male given name",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Amun-Re": {
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
+    },
+    "Amun-Re": {
       "gpt-4o-mini": {
         "id": "Q58373",
         "description": "Egyptian and Berber deity"
       }
     }
   },
-  "Book of the Dead of Aaner": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": {
-        "id": "Q117398410",
-        "description": "papyurs of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1771)"
-      }
-    }
-  },
-  "Mut": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "papyurs of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1771)"
-      }
-    }
-  },
-  "Cyperus": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": {
-        "id": "Q161224",
-        "description": "genus of plants"
-      }
-    }
-  },
-  "Book of the Dead of Iuefankh": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": {
-        "id": "Q117398419",
-        "description": "papyurs of the Egyptian Hellenistic period, 332–30 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.1791)"
-      }
-    }
-  },
-  "Cyperus papyrus": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": {
-        "id": "Q158808",
-        "description": "species of aquatic flowering plant"
-      }
-    }
-  },
-  "Ptolemaic period": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "species of aquatic flowering plant"
-      }
-    }
-  },
-  "Drovetti collection": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "ancient Egyptian city"
-      }
-    }
-  },
-  "Tamutmutef": {
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "ancient Egyptian city"
-      }
-    }
-  },
-  "Ptolemaic Period": {
-    "Fragment of a mummy mask decorated with a mummification scene. Cartonnage. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2250": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "ancient Egyptian city"
-      }
-    },
-    "Coffin for a fish, containing mummy. Wood, organic remains. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2393/1": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "peninsula in Western Asia"
-      }
-    },
-    "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "village in Giza Governorate, Egypt"
-      }
-    },
-    "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "inner organ for the circulation of blood"
-      }
-    }
-  },
-  "Asiatic": {
-    "Mummy soles picturing two Asiatic prisoners, symbolizing the trampling of the enemy. Linen. Late Period (722-332 BC).. Acquired before 1882. C. 2328": {
-      "gpt-4o-mini": {
-        "id": "Q51614",
-        "description": "peninsula in Western Asia"
-      }
-    }
-  },
-  "25th Dynasty": {
-    "Shabti-box. Wood. Late Period, 25th Dynasty (722-664 BC). . Acquired before 1882. C. 2441": {
-      "gpt-4o-mini": {
-        "id": "Q737648",
-        "description": "Kushite rule in Egypt during the third intermediate period"
-      }
-    }
-  },
-  "Mesmeni": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": {
-        "id": "None",
-        "description": "Kushite rule in Egypt during the third intermediate period"
-      }
-    }
-  },
-  "New Kingdom": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
-      }
-    },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
+  "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q180568",
-        "description": "period from 1550 to 1077 BC in ancient Egypt",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "20th Dynasty": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": {
-        "id": "Q583501",
-        "description": "Period from 1189 to 1077 BCE"
-      }
-    }
-  },
-  "Horemakhbit": {
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
+    },
+    "Horemakhbit": {
       "gpt-4o-mini": {
         "id": "[]",
         "description": "Period from 1189 to 1077 BCE"
       }
-    }
-  },
-  "Deir el-Bahari": {
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
+    },
+    "Deir el-Bahari": {
       "gpt-4o-mini": {
         "id": "Q373909",
         "description": "archaeological site"
@@ -984,68 +1208,45 @@
         "description": "archaeological site",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Khonsu": {
-    "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
-      "gpt-4o-mini": {
-        "id": "Q190521",
-        "description": "Egyptian deity"
-      },
+    },
+    "Shabti of Horemakhbit": {
       "qwen3:8b": {
-        "id": "Q56509044",
-        "description": "statuette of Khonsu as a falcon-headed man crowned with a lunar disc",
+        "id": "Q117396490",
+        "description": "faience shabti of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.2724/a)",
         "model": "qwen3:8b"
       }
     }
   },
-  "Tuthmosis III": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": {
-        "id": "Q157899",
-        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      },
+  "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100": {
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q157899",
-        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
     },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
+    "New Kingdom": {
       "gpt-4o-mini": {
-        "id": "Q157899",
-        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      },
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    }
+  },
+  "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
+    "Drovetti": {
       "qwen3:8b": {
-        "id": "Q157899",
-        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty",
+        "id": "Q822895",
+        "description": "Italian diplomat, explorer and scholar",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Djehuty": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
+    },
+    "New Kingdom": {
       "gpt-4o-mini": {
-        "id": "Q912046",
-        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\""
-      },
-      "qwen3:8b": {
-        "id": "Q912046",
-        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\"",
-        "model": "qwen3:8b"
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
       }
-    }
-  },
-  "Tuthmosi III": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\""
-      }
-    }
-  },
-  "Amennakht": {
-    "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
+    },
+    "Amennakht": {
       "gpt-4o-mini": {
         "id": "[]",
         "description": "Italian diplomat, explorer and scholar"
@@ -1057,324 +1258,156 @@
       }
     }
   },
-  "Wadjren": {
-    "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
+  "Amulet depicting the god Harpocrates": {
+    "Harpocrates": {
       "gpt-4o-mini": {
-        "id": "[]",
-        "description": "period from 1550 to 1077 BC in ancient Egypt"
+        "id": "Q787492",
+        "description": "God-child in Egyptian mythology"
       },
       "qwen3:8b": {
-        "id": "",
-        "description": "",
+        "id": "Q787492",
+        "description": "God-child in Egyptian mythology",
         "model": "qwen3:8b"
       }
     }
   },
-  "Cyprus": {
-    "Double juglet of the “Base Ring I” type, imported from Cyprus. Baked clay. New Kingdom, 18th Dynasty (1539-1292 BC).. Acquired before 1888. C. 3673": {
+  "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
+    "Statue": {
       "gpt-4o-mini": {
-        "id": "Q229",
-        "description": "Mediterranean island country in West Asia"
-      },
-      "qwen3:8b": {
-        "id": "Q229",
-        "description": "Mediterranean island country in West Asia",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "1888": {
-    "Scarab. Faience. Late Period – Ptolemaic Period (722-30 BC).. Acquired before 1888. C. 6098": {
-      "gpt-4o-mini": {
-        "id": "Q7829",
-        "description": "year"
-      }
-    }
-  },
-  "Amenemope": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": {
-        "id": "Q2844817",
-        "description": "ancient Egyptian writer"
-      },
-      "qwen3:8b": {
-        "id": "Q2844817",
-        "description": "ancient Egyptian writer",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Horemheb": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": {
-        "id": "Q157995",
-        "description": "final pharaoh of the 18th dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q157995",
-        "description": "final pharaoh of the 18th dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Saqqara": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": {
-        "id": "Q192134",
-        "description": "village in Giza Governorate, Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q192134",
-        "description": "village in Giza Governorate, Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Roman Period": {
-    "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
-      "gpt-4o-mini": {
-        "id": "Q125510349",
-        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+        "id": "Q179700",
+        "description": "sculpture primarily conceived as a representational figure"
       }
     },
-    "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
+    "Bes": {
       "gpt-4o-mini": {
-        "id": "Q125510349",
-        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+        "id": "Q37776",
+        "description": "commune in Doubs, France"
       }
     },
-    "Lid. Glass. Roman Period (30 BC-AD 395).. P. 5178": {
+    "Ptolemaic": {
       "gpt-4o-mini": {
-        "id": "Q125510349",
-        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+        "id": "Q2320005",
+        "description": "Hellenistic kingdom in ancient Egypt from 305 to 30 BC"
+      }
+    },
+    "Roman": {
+      "gpt-4o-mini": {
+        "id": "Q218",
+        "description": "country in Southeast Europe"
       }
     }
   },
-  "deity": {
-    "Amulet depicting a hybrid deity": {
+  "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
+    "Roman": {
       "gpt-4o-mini": {
-        "id": "Q178885",
-        "description": "natural or supernatural god or goddess, divine being"
+        "id": "Q218",
+        "description": "country in Southeast Europe"
       }
-    }
-  },
-  "heart": {
-    "Amulet depicting the heart": {
-      "gpt-4o-mini": {
-        "id": "Q1072",
-        "description": "inner organ for the circulation of blood"
-      }
-    }
-  },
-  "Attis": {
-    "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
+    },
+    "Attis": {
       "gpt-4o-mini": {
         "id": "Q262016",
         "description": "Phrygian and Greek mythological figure"
       }
     }
   },
-  "Nephthys": {
-    "Amulet depicting the goddess Nephthys": {
+  "Amulet depicting the wedjat-eye": {
+    "wedjat-eye": {
       "gpt-4o-mini": {
-        "id": "Q169040",
+        "id": "Q116419933",
+        "description": "amulet, Wedjat eye at the Metropolitan Museum of Art (MET, O.C.2887)"
+      }
+    }
+  },
+  "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Khonsu": {
+      "gpt-4o-mini": {
+        "id": "Q190521",
         "description": "Egyptian deity"
       },
       "qwen3:8b": {
-        "id": "Q169040",
-        "description": "Egyptian deity",
+        "id": "Q56509044",
+        "description": "statuette of Khonsu as a falcon-headed man crowned with a lunar disc",
         "model": "qwen3:8b"
       }
     }
   },
-  "Calcite": {
-    "Dish. Calcite (alabaster). Early Dynastic Period, 1st-2nd Dynasty (3000-2590 BC).. P. 795": {
+  "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q171917",
-        "description": "carbonate mineral"
-      }
-    }
-  },
-  "Tamit": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": {
-        "id": "Q16023139",
-        "description": "human settlement in Onezhsky District, Arkhangelsk Oblast, Russia"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "",
-        "description": "",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
     },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "African man": {
       "gpt-4o-mini": {
         "id": "[]",
-        "description": "Italian university founded in Rome in 1303"
-      },
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
+        "description": "family name"
       }
     }
   },
-  "Egyptian Nubia": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
+  "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "[]",
-        "description": "human settlement in Onezhsky District, Arkhangelsk Oblast, Russia"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "Q125517012",
-        "description": "journal article from 'Current Anthropology' published in 1973",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
     },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "Italian university founded in Rome in 1303"
-      },
+    "Schiaparelli": {
       "qwen3:8b": {
-        "id": "Q125517012",
-        "description": "journal article from 'Current Anthropology' published in 1973",
+        "id": "Q47495517",
+        "description": "family name",
         "model": "qwen3:8b"
       }
     }
   },
-  "Istituto Egittologia": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
+  "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q134385372",
-        "description": "Egyptological studies institution of the University of Rome \"La Sapienza\", Italy"
-      }
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": {
-        "id": "Q134385372",
-        "description": "Egyptological studies institution of the University of Rome \"La Sapienza\", Italy"
-      }
-    }
-  },
-  "University of Rome": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": {
-        "id": "Q209344",
-        "description": "Italian university founded in Rome in 1303"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "Q209344",
-        "description": "Italian university founded in Rome in 1303",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
     },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
+    "New Kingdom": {
       "gpt-4o-mini": {
-        "id": "Q209344",
-        "description": "Italian university founded in Rome in 1303"
-      },
-      "qwen3:8b": {
-        "id": "Q209344",
-        "description": "Italian university founded in Rome in 1303",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "worshiper": {
-    "Statuette of a worshiper. Bronze. Late Period (722-332 BC).. P. 3552": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "Italian university founded in Rome in 1303"
-      }
-    }
-  },
-  "Nubia": {
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": {
-        "id": "Q135028",
-        "description": "region along the Nile river, which is located in northern Sudan and southern Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q135028",
-        "description": "region along the Nile river, which is located in northern Sudan and southern Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Amulet": {
-    "Amulet depicting the god Nefertum": {
-      "gpt-4o-mini": {
-        "id": "Q131557",
-        "description": "object that is typically worn on one's person, and is alleged to have the magical power to protect its holder"
-      }
-    }
-  },
-  "Nefertum": {
-    "Amulet depicting the god Nefertum": {
-      "gpt-4o-mini": {
-        "id": "Q464227",
-        "description": "Egyptian deity"
-      }
-    }
-  },
-  "Shabti": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": {
-        "id": "Q117424738",
-        "description": "alabaster shabti of the Egyptian New Kingdom, 1539–1076 BCE, in the collection of Museo Egizio, Turin, Italy"
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
       }
     },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": {
-        "id": "Q726826",
-        "description": "funerary figurine used in ancient Egyptian religion"
-      }
-    }
-  },
-  "Alabaster": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": {
-        "id": "Q143447",
-        "description": "gypsum variety"
-      }
-    }
-  },
-  "Museo Kircheriano": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": {
-        "id": "Q1530830",
-        "description": "former museum in Rome, Italy"
-      },
-      "qwen3:8b": {
-        "id": "Q1530830",
-        "description": "former museum in Rome, Italy",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Naqada": {
-    "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
-      "gpt-4o-mini": {
-        "id": "Q753391",
-        "description": "archaeological culture of pre-dynastic Egypt"
-      }
-    },
-    "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
-      "gpt-4o-mini": {
-        "id": "Q753391",
-        "description": "archaeological culture of pre-dynastic Egypt"
-      }
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "gpt-4o-mini": {
-        "id": "Q753391",
-        "description": "archaeological culture of pre-dynastic Egypt"
-      }
-    }
-  },
-  "Schiaparelli": {
-    "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
+    "Schiaparelli": {
       "gpt-4o-mini": {
         "id": "Q47495517",
         "description": "family name"
@@ -1384,96 +1417,105 @@
         "description": "family name",
         "model": "qwen3:8b"
       }
-    },
-    "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
+    }
+  },
+  "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "Q107835110",
-        "description": "French fashion house",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
     },
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
+    "New Kingdom": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
       }
     },
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
+    "Schiaparelli": {
       "qwen3:8b": {
         "id": "Q47495517",
         "description": "family name",
         "model": "qwen3:8b"
       }
-    },
-    "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
+    }
+  },
+  "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Schiaparelli": {
       "qwen3:8b": {
         "id": "Q47495517",
         "description": "family name",
         "model": "qwen3:8b"
       }
-    },
-    "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
+    }
+  },
+  "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Schiaparelli": {
       "qwen3:8b": {
         "id": "Q47495517",
         "description": "family name",
         "model": "qwen3:8b"
       }
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
+    }
+  },
+  "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
+    "Deir el-Medina": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
       },
       "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
         "model": "qwen3:8b"
       }
     },
-    "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
+    "New Kingdom": {
       "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
       }
     },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
+    "Schiaparelli": {
       "gpt-4o-mini": {
         "id": "Q2234103",
         "description": "lunar crater"
@@ -1484,1083 +1526,7 @@
         "model": "qwen3:8b"
       }
     },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q617030",
-        "description": "crater on Mars"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": {
-        "id": "Q2234103",
-        "description": "lunar crater"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q2234103",
-        "description": "lunar crater"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q617030",
-        "description": "crater on Mars"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": {
-        "id": "Q2234103",
-        "description": "lunar crater"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": {
-        "id": "Q2234103",
-        "description": "lunar crater"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
-      "gpt-4o-mini": {
-        "id": "Q2234103",
-        "description": "lunar crater"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
-      "gpt-4o-mini": {
-        "id": "Q3061991",
-        "description": "ExoMars 2016 lander module"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": {
-        "id": "Q3061991",
-        "description": "ExoMars 2016 lander module"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": {
-        "id": "Q3061991",
-        "description": "ExoMars 2016 lander module"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": {
-        "id": "None",
-        "description": "female given name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": {
-        "id": "Q3061991",
-        "description": "ExoMars 2016 lander module"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": {
-        "id": "Q3061991",
-        "description": "ExoMars 2016 lander module"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": {
-        "id": "Q47495517",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
-      "gpt-4o-mini": {
-        "id": "Q107835110",
-        "description": "French fashion house"
-      },
-      "qwen3:8b": {
-        "id": "Q107835110",
-        "description": "French fashion house",
-        "model": "qwen3:8b"
-      }
-    },
-    "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "qwen3:8b": {
-        "id": "Q47495517",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Predynastic Period": {
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
-      "gpt-4o-mini": {
-        "id": "Q714601",
-        "description": "period of ancient Egyptian history"
-      }
-    }
-  },
-  "Naqada II": {
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
-      "gpt-4o-mini": {
-        "id": "Q721840",
-        "description": "last phase of the Naqada culture of ancient Egyptian prehistory"
-      },
-      "qwen3:8b": {
-        "id": "Q721840",
-        "description": "last phase of the Naqada culture of ancient Egyptian prehistory",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "oarsmen": {
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": {
-        "id": "Q12957220",
-        "description": "Oarsmen on a galley"
-      }
-    }
-  },
-  "Asyut": {
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029": {
-      "gpt-4o-mini": {
-        "id": "Q29962",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "qwen3:8b": {
-        "id": "Q29962",
-        "description": "City in Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Stela of Inheretnakht": {
-    "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
-      "gpt-4o-mini": {
-        "id": "Q117424268",
-        "description": "limestone stela of the Egyptian First Intermediate Period, 2118–1980 BCE, in the collection of Museo Egizio, Turin, Italy (S.1264)"
-      }
-    }
-  },
-  "Hammamiya": {
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "gpt-4o-mini": {
-        "id": "Q1604678",
-        "description": "human settlement"
-      },
-      "qwen3:8b": {
-        "id": "Q1604678",
-        "description": "human settlement",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Valley of the Queens": {
-    "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
-      "gpt-4o-mini": {
-        "id": "Q260386",
-        "description": "ancient Egyptian necropolis"
-      },
-      "qwen3:8b": {
-        "id": "Q260386",
-        "description": "ancient Egyptian necropolis",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "African man": {
-    "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "family name"
-      }
-    }
-  },
-  "Djefahapi": {
-    "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Amenhotep II": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q42606",
-        "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": {
-        "id": "Q158052",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
-    }
-  },
-  "Tuthmosis IV": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": {
-        "id": "Q157985",
-        "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
-    }
-  },
-  "Bowl": {
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": {
-        "id": "Q153988",
-        "description": "circular, open-top container frequently used as tableware"
-      }
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": {
-        "id": "Q153988",
-        "description": "circular, open-top container frequently used as tableware"
-      }
-    }
-  },
-  "Kha": {
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      },
-      "qwen3:8b": {
-        "id": "Q16277895",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      }
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      }
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      },
-      "qwen3:8b": {
-        "id": "Q2740671",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      },
-      "qwen3:8b": {
-        "id": "Q16277895",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": {
-        "id": "Q16277895",
-        "description": "male given name"
-      },
-      "qwen3:8b": {
-        "id": "Q16277895",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q2740671",
-        "description": "family name"
-      }
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "qwen3:8b": {
-        "id": "Q16277895",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "qwen3:8b": {
-        "id": "Q16277895",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Persea": {
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q132039",
-        "description": "genus of plants"
-      }
-    }
-  },
-  "papyrus": {
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": {
-        "id": "Q158808",
-        "description": "species of aquatic flowering plant"
-      }
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q125576",
-        "description": "writing and painting material"
-      }
-    }
-  },
-  "Pestle": {
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": {
-        "id": "Q907209",
-        "description": "Blunt tool to grind things in a mortar"
-      }
-    }
-  },
-  "18th Dynasty": {
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": {
-        "id": "Q146055",
-        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut"
-      }
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q146055",
-        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut"
-      }
-    },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "Q146055",
-        "description": "Dynasty of Egypt between 1550 BCE and 1295 BCE, notably comprising Akenaten and Hatshepsut",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Lidded basket": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q117429170",
-        "description": "plant fiber basket of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8414)"
-      }
-    }
-  },
-  "juniper berries": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "plant fiber basket of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8414)"
-      }
-    }
-  },
-  "Vegetable fibers": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": {
-        "id": "Q117233367",
-        "description": "plant fibers of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy"
-      }
-    }
-  },
-  "Tunic": {
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": {
-        "id": "Q201714",
-        "description": "simple T-shaped or sleeveless garment, usually unfitted, of archaic origin"
-      }
-    }
-  },
-  "Kohl tube": {
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": {
-        "id": "Q116273799",
-        "description": "kohl tube, papyrus column at the Metropolitan Museum of Art (MET, 91.1.1351)"
-      }
-    }
-  },
-  "Cup": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q81727",
-        "description": "vessel for liquids"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": {
-        "id": "Q81727",
-        "description": "vessel for liquids"
-      }
-    }
-  },
-  "Baked clay": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q42302",
-        "description": "soft rock based compound often used for sculpture and tools"
-      }
-    }
-  },
-  "Middle Kingdom": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q191324",
-        "description": "period in the history of ancient Egypt between about 2000 BC and 1700 BC"
-      }
-    }
-  },
-  "12th Dynasty": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q719639",
-        "description": "Egyptian dynasty from 1991 to 1802 BCE"
-      }
-    }
-  },
-  "Sesostris I": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "Q18763",
-        "description": "pharaoh of Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q18763",
-        "description": "pharaoh of Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Shemes": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "City in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Tomb of Minhotep": {
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": {
-        "id": "Q134283924",
-        "description": "ancient egyptian tomb in Asyut, Egypt"
-      }
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "qwen3:8b": {
-        "id": "Q134283924",
-        "description": "ancient egyptian tomb in Asyut, Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Tomb": {
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": {
-        "id": "Q381885",
-        "description": "burial place"
-      }
-    }
-  },
-  "Minhotep": {
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "burial place"
-      }
-    },
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Menna": {
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
+    "Menna": {
       "gpt-4o-mini": {
         "id": "Q6817163",
         "description": "ancient Egyptian scribe"
@@ -2570,10 +1536,8 @@
         "description": "ancient Egyptian scribe",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Ramesses III": {
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
+    },
+    "Ramesses III": {
       "gpt-4o-mini": {
         "id": "Q1528",
         "description": "Egyptian pharaoh of the 20th dynasty"
@@ -2585,8 +1549,56 @@
       }
     }
   },
-  "Nespayherhat": {
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
+  "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings"
+      },
+      "qwen3:8b": {
+        "id": "Q750212",
+        "description": "ancient Egyptian village in the Valley of the Kings",
+        "model": "qwen3:8b"
+      }
+    },
+    "Shabti": {
+      "gpt-4o-mini": {
+        "id": "Q726826",
+        "description": "funerary figurine used in ancient Egyptian religion"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Nespayherhat": {
       "gpt-4o-mini": {
         "id": "[]",
         "description": "funerary figurine used in ancient Egyptian religion"
@@ -2598,194 +1610,952 @@
       }
     }
   },
-  "Gebelein": {
-    "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
+  "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+    "Ramesses II": {
       "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
+        "id": "Q1523",
+        "description": "Egyptian third pharaoh of the Nineteenth Dynasty"
       },
       "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
+        "id": "Q1523",
+        "description": "Egyptian third pharaoh of the Nineteenth Dynasty",
         "model": "qwen3:8b"
       }
     },
-    "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
+    "Re": {
       "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
+        "id": "Q20148490",
+        "description": "family name"
+      }
+    },
+    "Heliopolis": {
+      "gpt-4o-mini": {
+        "id": "Q191687",
+        "description": "city of ancient Egypt"
       },
       "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
+        "id": "Q191687",
+        "description": "city of ancient Egypt",
         "model": "qwen3:8b"
       }
     },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
+    "Abydos": {
       "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
+        "id": "Q192268",
+        "description": "city in ancient Egypt"
       },
       "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
+        "id": "Q192268",
+        "description": "city in ancient Egypt",
         "model": "qwen3:8b"
       }
     },
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
+    "Meh": {
       "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
+        "id": "Q19817828",
+        "description": "male given name",
         "model": "qwen3:8b"
       }
     },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
+    "Merenptah": {
       "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
-        "model": "qwen3:8b"
-      }
-    },
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q1496830",
-        "description": "village and archaeological site in Egypt",
+        "id": "Q158059",
+        "description": "Penultimate Pharaoh of the 19th dynasty",
         "model": "qwen3:8b"
       }
     }
   },
-  "Hathor": {
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
+  "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
+    "Heliopolis": {
+      "gpt-4o-mini": {
+        "id": "Q191687",
+        "description": "city of ancient Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q191687",
+        "description": "city of ancient Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Fragment of a mummy mask decorated with a mummification scene. Cartonnage. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2250": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "ancient Egyptian city"
+      }
+    }
+  },
+  "Coffin for a fish, containing mummy. Wood, organic remains. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2393/1": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "peninsula in Western Asia"
+      }
+    }
+  },
+  "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "village in Giza Governorate, Egypt"
+      }
+    },
+    "Roman Period": {
+      "gpt-4o-mini": {
+        "id": "Q125510349",
+        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+      }
+    }
+  },
+  "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "inner organ for the circulation of blood"
+      }
+    },
+    "Roman Period": {
+      "gpt-4o-mini": {
+        "id": "Q125510349",
+        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+      }
+    }
+  },
+  "Mummy soles picturing two Asiatic prisoners, symbolizing the trampling of the enemy. Linen. Late Period (722-332 BC).. Acquired before 1882. C. 2328": {
+    "Asiatic": {
+      "gpt-4o-mini": {
+        "id": "Q51614",
+        "description": "peninsula in Western Asia"
+      }
+    }
+  },
+  "Shabti-box. Wood. Late Period, 25th Dynasty (722-664 BC). . Acquired before 1882. C. 2441": {
+    "25th Dynasty": {
+      "gpt-4o-mini": {
+        "id": "Q737648",
+        "description": "Kushite rule in Egypt during the third intermediate period"
+      }
+    }
+  },
+  "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
+    "Mesmeni": {
+      "gpt-4o-mini": {
+        "id": "None",
+        "description": "Kushite rule in Egypt during the third intermediate period"
+      }
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "20th Dynasty": {
+      "gpt-4o-mini": {
+        "id": "Q583501",
+        "description": "Period from 1189 to 1077 BCE"
+      }
+    },
+    "construction worker Mesmeni": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Wadjren": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      },
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Shabti": {
+      "gpt-4o-mini": {
+        "id": "Q117424738",
+        "description": "alabaster shabti of the Egyptian New Kingdom, 1539–1076 BCE, in the collection of Museo Egizio, Turin, Italy"
+      }
+    },
+    "Alabaster": {
+      "gpt-4o-mini": {
+        "id": "Q143447",
+        "description": "gypsum variety"
+      }
+    },
+    "Museo Kircheriano": {
+      "gpt-4o-mini": {
+        "id": "Q1530830",
+        "description": "former museum in Rome, Italy"
+      },
+      "qwen3:8b": {
+        "id": "Q1530830",
+        "description": "former museum in Rome, Italy",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
+    "New Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q180568",
+        "description": "period from 1550 to 1077 BC in ancient Egypt"
+      }
+    },
+    "Akhenaten": {
+      "gpt-4o-mini": {
+        "id": "Q81794",
+        "description": "Egyptian pharaoh in 18th Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q81794",
+        "description": "Egyptian pharaoh in 18th Dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Munich": {
+      "gpt-4o-mini": {
+        "id": "Q1726",
+        "description": "capital and most populous city of Bavaria, Germany"
+      },
+      "qwen3:8b": {
+        "id": "Q1726",
+        "description": "capital and most populous city of Bavaria, Germany",
+        "model": "qwen3:8b"
+      }
+    },
+    "Turin Rotary Club": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "capital and most populous city of Bavaria, Germany"
+      }
+    },
+    "Turin": {
+      "qwen3:8b": {
+        "id": "Q495",
+        "description": "city and commune in Italy",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
+    "Tuthmosis III": {
+      "gpt-4o-mini": {
+        "id": "Q157899",
+        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q157899",
+        "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q3061991",
+        "description": "ExoMars 2016 lander module"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Hathor": {
       "gpt-4o-mini": {
         "id": "Q133343",
         "description": "major goddess in ancient Egyptian religion"
       }
     }
   },
-  "Iti": {
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
+  "Double juglet of the “Base Ring I” type, imported from Cyprus. Baked clay. New Kingdom, 18th Dynasty (1539-1292 BC).. Acquired before 1888. C. 3673": {
+    "Cyprus": {
+      "gpt-4o-mini": {
+        "id": "Q229",
+        "description": "Mediterranean island country in West Asia"
+      },
+      "qwen3:8b": {
+        "id": "Q229",
+        "description": "Mediterranean island country in West Asia",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Scarab. Faience. Late Period – Ptolemaic Period (722-30 BC).. Acquired before 1888. C. 6098": {
+    "1888": {
+      "gpt-4o-mini": {
+        "id": "Q7829",
+        "description": "year"
+      }
+    }
+  },
+  "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
+    "Amenemope": {
+      "gpt-4o-mini": {
+        "id": "Q2844817",
+        "description": "ancient Egyptian writer"
+      },
+      "qwen3:8b": {
+        "id": "Q2844817",
+        "description": "ancient Egyptian writer",
+        "model": "qwen3:8b"
+      }
+    },
+    "Horemheb": {
+      "gpt-4o-mini": {
+        "id": "Q157995",
+        "description": "final pharaoh of the 18th dynasty of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q157995",
+        "description": "final pharaoh of the 18th dynasty of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Saqqara": {
+      "gpt-4o-mini": {
+        "id": "Q192134",
+        "description": "village in Giza Governorate, Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q192134",
+        "description": "village in Giza Governorate, Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Lid. Glass. Roman Period (30 BC-AD 395).. P. 5178": {
+    "Roman Period": {
+      "gpt-4o-mini": {
+        "id": "Q125510349",
+        "description": "period of Rome's political and cultural supremacy in much of Europe, North Africa and the Near East"
+      }
+    }
+  },
+  "Amulet depicting a hybrid deity": {
+    "deity": {
+      "gpt-4o-mini": {
+        "id": "Q178885",
+        "description": "natural or supernatural god or goddess, divine being"
+      }
+    }
+  },
+  "Amulet depicting the heart": {
+    "heart": {
+      "gpt-4o-mini": {
+        "id": "Q1072",
+        "description": "inner organ for the circulation of blood"
+      }
+    }
+  },
+  "Amulet depicting the goddess Nephthys": {
+    "Nephthys": {
+      "gpt-4o-mini": {
+        "id": "Q169040",
+        "description": "Egyptian deity"
+      },
+      "qwen3:8b": {
+        "id": "Q169040",
+        "description": "Egyptian deity",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Dish. Calcite (alabaster). Early Dynastic Period, 1st-2nd Dynasty (3000-2590 BC).. P. 795": {
+    "Calcite": {
+      "gpt-4o-mini": {
+        "id": "Q171917",
+        "description": "carbonate mineral"
+      }
+    }
+  },
+  "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
+    "Tamit": {
+      "gpt-4o-mini": {
+        "id": "Q16023139",
+        "description": "human settlement in Onezhsky District, Arkhangelsk Oblast, Russia"
+      },
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    },
+    "Egyptian Nubia": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "human settlement in Onezhsky District, Arkhangelsk Oblast, Russia"
+      },
+      "qwen3:8b": {
+        "id": "Q125517012",
+        "description": "journal article from 'Current Anthropology' published in 1973",
+        "model": "qwen3:8b"
+      }
+    },
+    "Istituto Egittologia": {
+      "gpt-4o-mini": {
+        "id": "Q134385372",
+        "description": "Egyptological studies institution of the University of Rome \"La Sapienza\", Italy"
+      }
+    },
+    "University of Rome": {
+      "gpt-4o-mini": {
+        "id": "Q209344",
+        "description": "Italian university founded in Rome in 1303"
+      },
+      "qwen3:8b": {
+        "id": "Q209344",
+        "description": "Italian university founded in Rome in 1303",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomb N. 1": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
+    "Tamit": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "Italian university founded in Rome in 1303"
+      },
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    },
+    "Egyptian Nubia": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "Italian university founded in Rome in 1303"
+      },
+      "qwen3:8b": {
+        "id": "Q125517012",
+        "description": "journal article from 'Current Anthropology' published in 1973",
+        "model": "qwen3:8b"
+      }
+    },
+    "Istituto Egittologia": {
+      "gpt-4o-mini": {
+        "id": "Q134385372",
+        "description": "Egyptological studies institution of the University of Rome \"La Sapienza\", Italy"
+      }
+    },
+    "University of Rome": {
+      "gpt-4o-mini": {
+        "id": "Q209344",
+        "description": "Italian university founded in Rome in 1303"
+      },
+      "qwen3:8b": {
+        "id": "Q209344",
+        "description": "Italian university founded in Rome in 1303",
+        "model": "qwen3:8b"
+      }
+    },
+    "Nubia": {
+      "gpt-4o-mini": {
+        "id": "Q135028",
+        "description": "region along the Nile river, which is located in northern Sudan and southern Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q135028",
+        "description": "region along the Nile river, which is located in northern Sudan and southern Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomb N. 1": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Statuette of a worshiper. Bronze. Late Period (722-332 BC).. P. 3552": {
+    "worshiper": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "Italian university founded in Rome in 1303"
+      }
+    }
+  },
+  "Amulet depicting the god Nefertum": {
+    "Amulet": {
+      "gpt-4o-mini": {
+        "id": "Q131557",
+        "description": "object that is typically worn on one's person, and is alleged to have the magical power to protect its holder"
+      }
+    },
+    "Nefertum": {
+      "gpt-4o-mini": {
+        "id": "Q464227",
+        "description": "Egyptian deity"
+      }
+    }
+  },
+  "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
+    "Naqada": {
+      "gpt-4o-mini": {
+        "id": "Q753391",
+        "description": "archaeological culture of pre-dynastic Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Naqada I-IIB": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
+    "Naqada": {
+      "gpt-4o-mini": {
+        "id": "Q753391",
+        "description": "archaeological culture of pre-dynastic Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q107835110",
+        "description": "French fashion house",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
+    "Naqada": {
+      "gpt-4o-mini": {
+        "id": "Q753391",
+        "description": "archaeological culture of pre-dynastic Egypt"
+      }
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Hammamiya": {
+      "gpt-4o-mini": {
+        "id": "Q1604678",
+        "description": "human settlement"
+      },
+      "qwen3:8b": {
+        "id": "Q1604678",
+        "description": "human settlement",
+        "model": "qwen3:8b"
+      }
+    },
+    "Naqada IIC": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Predynastic Period": {
+      "gpt-4o-mini": {
+        "id": "Q714601",
+        "description": "period of ancient Egyptian history"
+      }
+    },
+    "Naqada II": {
+      "gpt-4o-mini": {
+        "id": "Q721840",
+        "description": "last phase of the Naqada culture of ancient Egyptian prehistory"
+      },
+      "qwen3:8b": {
+        "id": "Q721840",
+        "description": "last phase of the Naqada culture of ancient Egyptian prehistory",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "oarsmen": {
+      "gpt-4o-mini": {
+        "id": "Q12957220",
+        "description": "Oarsmen on a galley"
+      }
+    },
+    "Asyut": {
+      "gpt-4o-mini": {
+        "id": "Q29962",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Stela of Inheretnakht": {
+      "gpt-4o-mini": {
+        "id": "Q117424268",
+        "description": "limestone stela of the Egyptian First Intermediate Period, 2118–1980 BCE, in the collection of Museo Egizio, Turin, Italy (S.1264)"
+      }
+    },
+    "Inheretnakht": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Valley of the Queens": {
+      "gpt-4o-mini": {
+        "id": "Q260386",
+        "description": "ancient Egyptian necropolis"
+      },
+      "qwen3:8b": {
+        "id": "Q260386",
+        "description": "ancient Egyptian necropolis",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Asyut": {
+      "gpt-4o-mini": {
+        "id": "Q29962",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Cup": {
+      "gpt-4o-mini": {
+        "id": "Q81727",
+        "description": "vessel for liquids"
+      }
+    },
+    "Baked clay": {
+      "gpt-4o-mini": {
+        "id": "Q42302",
+        "description": "soft rock based compound often used for sculpture and tools"
+      }
+    },
+    "Middle Kingdom": {
+      "gpt-4o-mini": {
+        "id": "Q191324",
+        "description": "period in the history of ancient Egypt between about 2000 BC and 1700 BC"
+      }
+    },
+    "12th Dynasty": {
+      "gpt-4o-mini": {
+        "id": "Q719639",
+        "description": "Egyptian dynasty from 1991 to 1802 BCE"
+      }
+    },
+    "Sesostris I": {
+      "gpt-4o-mini": {
+        "id": "Q18763",
+        "description": "pharaoh of Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q18763",
+        "description": "pharaoh of Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Shemes": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Asyut": {
+      "gpt-4o-mini": {
+        "id": "Q29962",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomb of Minhotep": {
+      "gpt-4o-mini": {
+        "id": "Q134283924",
+        "description": "ancient egyptian tomb in Asyut, Egypt"
+      }
+    },
+    "Minhotep": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q2234103",
+        "description": "lunar crater"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Asyut": {
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Cup": {
+      "gpt-4o-mini": {
+        "id": "Q81727",
+        "description": "vessel for liquids"
+      }
+    },
+    "Tomb of Minhotep": {
+      "qwen3:8b": {
+        "id": "Q134283924",
+        "description": "ancient egyptian tomb in Asyut, Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomb": {
+      "gpt-4o-mini": {
+        "id": "Q381885",
+        "description": "burial place"
+      }
+    },
+    "Minhotep": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "burial place"
+      }
+    }
+  },
+  "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q2234103",
+        "description": "lunar crater"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
       "gpt-4o-mini": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
@@ -2796,7 +2566,42 @@
         "model": "qwen3:8b"
       }
     },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
       "gpt-4o-mini": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
@@ -2807,35 +2612,78 @@
         "model": "qwen3:8b"
       }
     },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
+    "Neferu": {
       "gpt-4o-mini": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty"
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort"
       },
       "qwen3:8b": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty",
+        "id": "Q228951",
+        "description": "Egyptian queen regnant",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q3061991",
+        "description": "ExoMars 2016 lander module"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
         "model": "qwen3:8b"
       }
     },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
+    "Gebelein": {
       "gpt-4o-mini": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty"
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
       },
       "qwen3:8b": {
-        "id": "Q105067186",
-        "description": "female given name",
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
         "model": "qwen3:8b"
       }
     },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
+    "Iti": {
+      "gpt-4o-mini": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty"
+      }
+    },
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q1218434",
+        "description": "given name"
+      }
+    }
+  },
+  "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q3061991",
+        "description": "ExoMars 2016 lander module"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
       "gpt-4o-mini": {
         "id": "Q130380013",
         "description": "family name"
@@ -2846,7 +2694,48 @@
         "model": "qwen3:8b"
       }
     },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Bowl": {
+      "gpt-4o-mini": {
+        "id": "Q153988",
+        "description": "circular, open-top container frequently used as tableware"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
       "gpt-4o-mini": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
@@ -2857,149 +2746,48 @@
         "model": "qwen3:8b"
       }
     },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
+    "Neferu": {
       "gpt-4o-mini": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty"
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort"
       },
       "qwen3:8b": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty"
-      },
-      "qwen3:8b": {
-        "id": "Q105067186",
-        "description": "female given name",
-        "model": "qwen3:8b"
-      }
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
-      "qwen3:8b": {
-        "id": "Q152375",
-        "description": "ancient Egyptian pharaoh of the First Dynasty",
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
         "model": "qwen3:8b"
       }
     }
   },
-  "Neferu": {
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
+  "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
+    "Schiaparelli": {
       "gpt-4o-mini": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort"
+        "id": "None",
+        "description": "female given name"
       },
       "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
+        "id": "Q47495517",
+        "description": "family name",
         "model": "qwen3:8b"
       }
     },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
+    "Gebelein": {
       "gpt-4o-mini": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort"
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
       },
       "qwen3:8b": {
-        "id": "Q228951",
-        "description": "Egyptian queen regnant",
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
         "model": "qwen3:8b"
       }
     },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": {
-        "id": "Q1218434",
-        "description": "given name"
-      }
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": {
-        "id": "Q1218434",
-        "description": "given name"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "gpt-4o-mini": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": {
-        "id": "Q1218434",
-        "description": "given name"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": {
-        "id": "Q1218434",
-        "description": "given name"
-      },
-      "qwen3:8b": {
-        "id": "Q277524",
-        "description": "ancient Egyptian queen consort",
-        "model": "qwen3:8b"
-      }
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
-      "qwen3:8b": {
-        "id": "Q228951",
-        "description": "Egyptian queen regnant",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Mummy": {
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
+    "Mummy": {
       "gpt-4o-mini": {
         "id": "Q43616",
         "description": "human or animal, whose skin and organs have been preserved"
       }
-    }
-  },
-  "Ini": {
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
+    },
+    "Ini": {
       "gpt-4o-mini": {
         "id": "Q23661445",
         "description": "female given name"
@@ -3011,40 +2799,132 @@
       }
     }
   },
-  "Old Kingdom": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
+  "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q3061991",
+        "description": "ExoMars 2016 lander module"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Old Kingdom": {
       "gpt-4o-mini": {
         "id": "Q177819",
         "description": "period of Ancient Egypt in the 3rd millennium BC"
       }
-    }
-  },
-  "5th Dynasty": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
+    },
+    "5th Dynasty": {
       "gpt-4o-mini": {
         "id": "[]",
         "description": "period of Ancient Egypt in the 3rd millennium BC"
       }
-    }
-  },
-  "1911": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
+    },
+    "1911": {
       "gpt-4o-mini": {
         "id": "Q2076",
         "description": "year"
       }
-    }
-  },
-  "greyhound": {
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": {
-        "id": "Q38571",
-        "description": "dog breed"
+    },
+    "Jug": {
+      "qwen3:8b": {
+        "id": "Q2413314",
+        "description": "container used to hold liquid",
+        "model": "qwen3:8b"
+      }
+    },
+    "Tomba Grande": {
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
       }
     }
   },
-  "Perim": {
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
+  "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q3061991",
+        "description": "ExoMars 2016 lander module"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
+      "gpt-4o-mini": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q105067186",
+        "description": "female given name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q1218434",
+        "description": "given name"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
+    "Schiaparelli": {
+      "gpt-4o-mini": {
+        "id": "Q47495517",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Perim": {
       "gpt-4o-mini": {
         "id": "Q1160017",
         "description": "island"
@@ -3054,10 +2934,8 @@
         "description": "island",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Shepset": {
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
+    },
+    "Shepset": {
       "gpt-4o-mini": {
         "id": "Q84959355",
         "description": "ancient Egyptian princess"
@@ -3069,55 +2947,25 @@
       }
     }
   },
-  "Fayum": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
+  "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
+    "Schiaparelli": {
       "gpt-4o-mini": {
-        "id": "Q203299",
-        "description": "city in Egypt"
+        "id": "Q107835110",
+        "description": "French fashion house"
       },
       "qwen3:8b": {
-        "id": "Q30656",
-        "description": "Egyptian governorate",
+        "id": "Q107835110",
+        "description": "French fashion house",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Hawara": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
-      "gpt-4o-mini": {
-        "id": "Q26237",
-        "description": "necropolis in Faiyum Governorate, Egypt"
-      },
-      "qwen3:8b": {
-        "id": "Q26237",
-        "description": "necropolis in Faiyum Governorate, Egypt",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Garré": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
-      "gpt-4o-mini": {
-        "id": "Q37560026",
-        "description": "family name"
-      },
-      "qwen3:8b": {
-        "id": "Q37560026",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Byzantine Period": {
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
+    },
+    "Byzantine Period": {
       "gpt-4o-mini": {
         "id": "Q117423418",
         "description": "clay bowl of the Byzantine Egypt, 395–642 CE, in the collection of Museo Egizio, Turin, Italy (S.2106)"
       }
-    }
-  },
-  "Museum of Cairo": {
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
+    },
+    "Museum of Cairo": {
       "gpt-4o-mini": {
         "id": "Q201219",
         "description": "museum in Cairo"
@@ -3129,42 +2977,273 @@
       }
     }
   },
-  "Akhenaten": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": {
-        "id": "Q81794",
-        "description": "Egyptian pharaoh in 18th Dynasty"
-      },
+  "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
+    "Schiaparelli": {
       "qwen3:8b": {
-        "id": "Q81794",
-        "description": "Egyptian pharaoh in 18th Dynasty",
+        "id": "Q47495517",
+        "description": "family name",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Munich": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
+    },
+    "Asyut": {
       "gpt-4o-mini": {
-        "id": "Q1726",
-        "description": "capital and most populous city of Bavaria, Germany"
+        "id": "Q29962",
+        "description": "City in Egypt"
       },
       "qwen3:8b": {
-        "id": "Q1726",
-        "description": "capital and most populous city of Bavaria, Germany",
+        "id": "Q29962",
+        "description": "City in Egypt",
         "model": "qwen3:8b"
       }
-    }
-  },
-  "Turin Rotary Club": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
+    },
+    "Djefahapi": {
       "gpt-4o-mini": {
         "id": "[]",
-        "description": "capital and most populous city of Bavaria, Germany"
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "",
+        "description": "",
+        "model": "qwen3:8b"
       }
     }
   },
-  "Tebtynis": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
+  "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Asyut": {
+      "gpt-4o-mini": {
+        "id": "Q29962",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Asyut": {
+      "gpt-4o-mini": {
+        "id": "Q29962",
+        "description": "City in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q29962",
+        "description": "City in Egypt",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
+      "gpt-4o-mini": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q105067186",
+        "description": "female given name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
+      "qwen3:8b": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Neferu": {
+      "qwen3:8b": {
+        "id": "Q228951",
+        "description": "Egyptian queen regnant",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
+    "Schiaparelli": {
+      "qwen3:8b": {
+        "id": "Q47495517",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    },
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
+      "gpt-4o-mini": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q1218434",
+        "description": "given name"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    },
+    "greyhound": {
+      "gpt-4o-mini": {
+        "id": "Q38571",
+        "description": "dog breed"
+      }
+    }
+  },
+  "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
+    "Gebelein": {
+      "gpt-4o-mini": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q1496830",
+        "description": "village and archaeological site in Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Iti": {
+      "gpt-4o-mini": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty"
+      },
+      "qwen3:8b": {
+        "id": "Q152375",
+        "description": "ancient Egyptian pharaoh of the First Dynasty",
+        "model": "qwen3:8b"
+      }
+    },
+    "Neferu": {
+      "gpt-4o-mini": {
+        "id": "Q1218434",
+        "description": "given name"
+      },
+      "qwen3:8b": {
+        "id": "Q277524",
+        "description": "ancient Egyptian queen consort",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
+    "Fayum": {
+      "gpt-4o-mini": {
+        "id": "Q203299",
+        "description": "city in Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q30656",
+        "description": "Egyptian governorate",
+        "model": "qwen3:8b"
+      }
+    },
+    "Hawara": {
+      "gpt-4o-mini": {
+        "id": "Q26237",
+        "description": "necropolis in Faiyum Governorate, Egypt"
+      },
+      "qwen3:8b": {
+        "id": "Q26237",
+        "description": "necropolis in Faiyum Governorate, Egypt",
+        "model": "qwen3:8b"
+      }
+    },
+    "Garré": {
+      "gpt-4o-mini": {
+        "id": "Q37560026",
+        "description": "family name"
+      },
+      "qwen3:8b": {
+        "id": "Q37560026",
+        "description": "family name",
+        "model": "qwen3:8b"
+      }
+    }
+  },
+  "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
+    "Tebtynis": {
       "gpt-4o-mini": {
         "id": "Q1500580",
         "description": "archaeological site in the Egyptian depression of el-Faiyum"
@@ -3175,15 +3254,7 @@
         "model": "qwen3:8b"
       }
     },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
-      "gpt-4o-mini": {
-        "id": "Q1500580",
-        "description": "archaeological site in the Egyptian depression of el-Faiyum"
-      }
-    }
-  },
-  "Anti": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
+    "Anti": {
       "gpt-4o-mini": {
         "id": "[]",
         "description": "archaeological site in the Egyptian depression of el-Faiyum"
@@ -3194,15 +3265,7 @@
         "model": "qwen3:8b"
       }
     },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
-      "gpt-4o-mini": {
-        "id": "[]",
-        "description": "archaeological site in the Egyptian depression of el-Faiyum"
-      }
-    }
-  },
-  "Bagnani": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
+    "Bagnani": {
       "gpt-4o-mini": {
         "id": "Q106632612",
         "description": "family name"
@@ -3212,206 +3275,47 @@
         "description": "family name",
         "model": "qwen3:8b"
       }
+    }
+  },
+  "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
+    "Tebtynis": {
+      "gpt-4o-mini": {
+        "id": "Q1500580",
+        "description": "archaeological site in the Egyptian depression of el-Faiyum"
+      }
     },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
+    "Anti": {
+      "gpt-4o-mini": {
+        "id": "[]",
+        "description": "archaeological site in the Egyptian depression of el-Faiyum"
+      }
+    },
+    "Bagnani": {
       "gpt-4o-mini": {
         "id": "Q106632612",
         "description": "family name"
       }
     }
   },
-  "Anubis": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
+  "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
+    "Anubis": {
       "gpt-4o-mini": {
         "id": "Q47534",
         "description": "Egyptian deity of mummification and the afterlife, usually depicted as a man with a canine head"
       }
-    }
-  },
-  "Tom": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
+    },
+    "Tom": {
       "qwen3:0.6b": {
         "id": "Q1238720",
         "description": "book in a series, typically identified sequentially (e.g. Volume 3)",
         "model": "qwen3:0.6b"
       }
-    }
-  },
-  "Egyptian Museum": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
+    },
+    "Egyptian Museum": {
       "qwen3:0.6b": {
         "id": "Q201219",
         "description": "museum in Cairo",
         "model": "qwen3:0.6b"
-      }
-    }
-  },
-  "Meh": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "qwen3:8b": {
-        "id": "Q19817828",
-        "description": "male given name",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Merenptah": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
-      "qwen3:8b": {
-        "id": "Q158059",
-        "description": "Penultimate Pharaoh of the 19th dynasty",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Aaner": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "qwen3:8b": {
-        "id": "Q37470770",
-        "description": "family name",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Iuefankh": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "qwen3:8b": {
-        "id": "Q125422532",
-        "description": "antico egizio",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Coffin of Tamutmutef": {
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "qwen3:8b": {
-        "id": "Q134774234",
-        "description": "wooden sarcophagus of the Twenty–first – Twenty–second Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–746 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.2228/01)",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "construction worker Mesmeni": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Shabti of Horemakhbit": {
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
-      "qwen3:8b": {
-        "id": "Q117396490",
-        "description": "faience shabti of the Twenty–first Dynasty of Egypt (Egyptian Third Intermediate Period), 1076–944 BCE, in the collection of Museo Egizio, Turin, Italy (Cat.2724/a)",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Tomb N. 1": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Naqada I-IIB": {
-    "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Inheretnakht": {
-    "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Naqada IIC": {
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Bread loaf": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "Q134774562",
-        "description": "bread of the Eighteenth Dynasty of Egypt (Egyptian New Kingdom), 1425–1353 BCE, in the collection of Museo Egizio, Turin, Italy (S.8278)",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Vegetable organic remains": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Tomb of Kha": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "Q648960",
-        "description": "ancient Egyptian tomb in the Valley of the Queens",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "S. 8273": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Jug": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "qwen3:8b": {
-        "id": "Q2413314",
-        "description": "container used to hold liquid",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Tomba Grande": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "qwen3:8b": {
-        "id": "",
-        "description": "",
-        "model": "qwen3:8b"
-      }
-    }
-  },
-  "Turin": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "qwen3:8b": {
-        "id": "Q495",
-        "description": "city and commune in Italy",
-        "model": "qwen3:8b"
       }
     }
   }

--- a/notebooks/tasks/disambiguation_cache_wikidata.json
+++ b/notebooks/tasks/disambiguation_cache_wikidata.json
@@ -2959,5 +2959,7 @@
       "id": "Q572434",
       "description": "fictional character from J.R.R. Tolkien's legendarium"
     }
-  ]
+  ],
+  "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": [],
+  "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": []
 }

--- a/notebooks/tasks/disambiguation_gold.json
+++ b/notebooks/tasks/disambiguation_gold.json
@@ -1,617 +1,971 @@
 [
   [
     {
-      "text": "Anubis",
-      "start": 21,
-      "end": 27,
+      "entity_text": "Anubis",
+      "start_char": 21,
+      "end_char": 27,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q47534",
         "description": "Egyptian deity of mummification and the afterlife, usually depicted as a man with a canine head"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 0,
+      "text": "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115"
     }
   ],
   [
     {
-      "text": "Sekhmet",
-      "start": 22,
-      "end": 29,
+      "entity_text": "Sekhmet",
+      "start_char": 22,
+      "end_char": 29,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q146104",
         "description": "Egyptian deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 1,
+      "text": "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256"
     },
     {
-      "text": "Amenhotep III",
-      "start": 81,
-      "end": 94,
+      "entity_text": "Amenhotep III",
+      "start_char": 81,
+      "end_char": 94,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 1,
+      "text": "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256"
     },
     {
-      "text": "Thebes",
-      "start": 111,
-      "end": 117,
+      "entity_text": "Thebes",
+      "start_char": 111,
+      "end_char": 117,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q101583",
         "description": "ancient Egyptian city"
-      }
+      },
+      "link_id": {
+        "id": 7,
+        "description": "the entity is a location where the artefact was created"
+      },
+      "text_id": 1,
+      "text": "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256"
     },
     {
-      "text": "Drovetti",
-      "start": 120,
-      "end": 128,
+      "entity_text": "Drovetti",
+      "start_char": 120,
+      "end_char": 128,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 1,
+      "text": "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256"
     }
   ],
   [
     {
-      "text": "Bastet",
-      "start": 25,
-      "end": 31,
+      "entity_text": "Bastet",
+      "start_char": 25,
+      "end_char": 31,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q129106",
         "description": "Egyptian cat deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 2,
+      "text": "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271"
     },
     {
-      "text": "Drovetti",
-      "start": 68,
-      "end": 76,
+      "entity_text": "Drovetti",
+      "start_char": 68,
+      "end_char": 76,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 2,
+      "text": "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271"
     }
   ],
   [
     {
-      "text": "Harpocrates",
-      "start": 25,
-      "end": 36,
+      "entity_text": "Harpocrates",
+      "start_char": 25,
+      "end_char": 36,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q787492",
         "description": "God-child in Egyptian mythology"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 3,
+      "text": "Amulet depicting the god Harpocrates"
     }
   ],
   [
     {
-      "text": "Satet",
-      "start": 25,
-      "end": 30,
+      "entity_text": "Satet",
+      "start_char": 25,
+      "end_char": 30,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q843206",
         "description": "ancient Egyptian goddess"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 4,
+      "text": "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515"
     },
     {
-      "text": "Drovetti",
-      "start": 67,
-      "end": 75,
+      "entity_text": "Drovetti",
+      "start_char": 67,
+      "end_char": 75,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 4,
+      "text": "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515"
     }
   ],
   [
     {
-      "text": "Bes",
-      "start": 18,
-      "end": 21,
+      "entity_text": "Bes",
+      "start_char": 18,
+      "end_char": 21,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q188931",
         "description": "Egyptian deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 5,
+      "text": "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638"
     }
   ],
   [
     {
-      "text": "Horus",
-      "start": 15,
-      "end": 20,
+      "entity_text": "Horus",
+      "start_char": 15,
+      "end_char": 20,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q84122",
         "description": "Egyptian sky deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 6,
+      "text": "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775"
     },
     {
-      "text": "Drovetti",
-      "start": 92,
-      "end": 100,
+      "entity_text": "Drovetti",
+      "start_char": 92,
+      "end_char": 100,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 6,
+      "text": "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775"
     }
   ],
   [
     {
-      "text": "Apis",
-      "start": 21,
-      "end": 25,
+      "entity_text": "Apis",
+      "start_char": 21,
+      "end_char": 25,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q208150",
         "description": "sacred bull in Egyptian mythology"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 7,
+      "text": "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815"
     },
     {
-      "text": "Drovetti",
-      "start": 62,
-      "end": 70,
+      "entity_text": "Drovetti",
+      "start_char": 62,
+      "end_char": 70,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 7,
+      "text": "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815"
     }
   ],
   [],
   [
     {
-      "text": "Amenhotep I.",
-      "start": 15,
-      "end": 27,
+      "entity_text": "Amenhotep I.",
+      "start_char": 15,
+      "end_char": 27,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157966",
         "description": "second Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 9,
+      "text": "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 81,
-      "end": 95,
+      "entity_text": "Deir el - Medina",
+      "start_char": 81,
+      "end_char": 95,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 9,
+      "text": "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372"
     },
     {
-      "text": "Drovetti",
-      "start": 98,
-      "end": 106,
+      "entity_text": "Drovetti",
+      "start_char": 98,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 9,
+      "text": "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372"
     }
   ],
   [
     {
-      "text": "Meh",
-      "start": 9,
-      "end": 12,
-      "gold_label": "PERSON"
+      "entity_text": "Meh",
+      "start_char": 9,
+      "end_char": 12,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Ramesses II",
-      "start": 54,
-      "end": 65,
+      "entity_text": "Ramesses II",
+      "start_char": 54,
+      "end_char": 65,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1523",
         "description": "Egyptian third pharaoh of the Nineteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Re",
-      "start": 86,
-      "end": 88,
+      "entity_text": "Re",
+      "start_char": 86,
+      "end_char": 88,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1252904",
         "description": "ancient Egyptian solar deity"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Heliopolis",
-      "start": 93,
-      "end": 103,
+      "entity_text": "Heliopolis",
+      "start_char": 93,
+      "end_char": 103,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q191687",
         "description": "city of ancient Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Ramesses II",
-      "start": 172,
-      "end": 183,
+      "entity_text": "Ramesses II",
+      "start_char": 172,
+      "end_char": 183,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1523",
         "description": "Egyptian third pharaoh of the Nineteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Merenptah",
-      "start": 199,
-      "end": 208,
+      "entity_text": "Merenptah",
+      "start_char": 199,
+      "end_char": 208,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158043",
         "description": "fourth pharaoh of the 19th Dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     },
     {
-      "text": "Abydos",
-      "start": 228,
-      "end": 234,
+      "entity_text": "Abydos",
+      "start_char": 228,
+      "end_char": 234,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q192268",
         "description": "city in ancient Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 10,
+      "text": "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor"
     }
   ],
   [
     {
-      "text": "Huy",
-      "start": 19,
-      "end": 22,
+      "entity_text": "Huy",
+      "start_char": 19,
+      "end_char": 22,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q5951403",
         "description": "ancient Egyptian high priest"
-      }
+      },
+      "link_id": {
+        "id": 2,
+        "description": "the entity is a person that created the artefact"
+      },
+      "text_id": 11,
+      "text": "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607"
     },
     {
-      "text": "Amun - Re",
-      "start": 26,
-      "end": 33,
+      "entity_text": "Amun - Re",
+      "start_char": 26,
+      "end_char": 33,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q481554",
         "description": "ancient Egyptian deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 11,
+      "text": "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 88,
-      "end": 102,
+      "entity_text": "Deir el - Medina",
+      "start_char": 88,
+      "end_char": 102,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 11,
+      "text": "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607"
     },
     {
-      "text": "Drovetti",
-      "start": 105,
-      "end": 113,
+      "entity_text": "Drovetti",
+      "start_char": 105,
+      "end_char": 113,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 11,
+      "text": "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607"
     }
   ],
   [
     {
-      "text": "Aaner",
-      "start": 20,
-      "end": 25,
-      "gold_label": "PERSON"
+      "entity_text": "Aaner",
+      "start_char": 20,
+      "end_char": 25,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 12,
+      "text": "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771"
     },
     {
-      "text": "Mut",
-      "start": 37,
-      "end": 40,
+      "entity_text": "Mut",
+      "start_char": 37,
+      "end_char": 40,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q14215956",
         "description": "town in the Egyptian depression of el-Dakhla"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 12,
+      "text": "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771"
     },
     {
-      "text": "Thebes",
-      "start": 114,
-      "end": 120,
+      "entity_text": "Thebes",
+      "start_char": 114,
+      "end_char": 120,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q101583",
         "description": "ancient Egyptian city"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 12,
+      "text": "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771"
     },
     {
-      "text": "Drovetti",
-      "start": 123,
-      "end": 131,
+      "entity_text": "Drovetti",
+      "start_char": 123,
+      "end_char": 131,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 12,
+      "text": "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771"
     }
   ],
   [
     {
-      "text": "Iuefankh",
-      "start": 20,
-      "end": 28,
+      "entity_text": "Iuefankh",
+      "start_char": 20,
+      "end_char": 28,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "",
         "description": "antico egizio (human)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 13,
+      "text": "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791"
     },
     {
-      "text": "Thebes",
-      "start": 78,
-      "end": 84,
+      "entity_text": "Thebes",
+      "start_char": 78,
+      "end_char": 84,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q101583",
         "description": "ancient Egyptian city"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 13,
+      "text": "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791"
     },
     {
-      "text": "Drovetti",
-      "start": 90,
-      "end": 98,
+      "entity_text": "Drovetti",
+      "start_char": 90,
+      "end_char": 98,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 13,
+      "text": "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791"
     }
   ],
   [
     {
-      "text": "Tamutmutef",
-      "start": 10,
-      "end": 20,
-      "gold_label": "PERSON"
+      "entity_text": "Tamutmutef",
+      "start_char": 10,
+      "end_char": 20,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 14,
+      "text": "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1"
     },
     {
-      "text": "Thebes",
-      "start": 88,
-      "end": 94,
+      "entity_text": "Thebes",
+      "start_char": 88,
+      "end_char": 94,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q101583",
         "description": "ancient Egyptian city"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 14,
+      "text": "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1"
     },
     {
-      "text": "Drovetti",
-      "start": 101,
-      "end": 109,
+      "entity_text": "Drovetti",
+      "start_char": 101,
+      "end_char": 109,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 14,
+      "text": "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1"
     }
   ],
   [],
   [
     {
-      "text": "Asiatic",
-      "start": 26,
-      "end": 33,
+      "entity_text": "Asiatic",
+      "start_char": 26,
+      "end_char": 33,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q48",
         "description": "biggest continent in the world"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 16,
+      "text": "Mummy soles picturing two Asiatic prisoners, symbolizing the trampling of the enemy. Linen. Late Period (722-332 BC).. Acquired before 1882. C. 2328"
     }
   ],
   [],
   [],
   [
     {
-      "text": "Mesmeni",
-      "start": 34,
-      "end": 41,
-      "gold_label": "PERSON"
+      "entity_text": "Mesmeni",
+      "start_char": 34,
+      "end_char": 41,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 19,
+      "text": "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646"
     }
   ],
   [
     {
-      "text": "Horemakhbit",
-      "start": 10,
-      "end": 21,
-      "gold_label": "PERSON"
+      "entity_text": "Horemakhbit",
+      "start_char": 10,
+      "end_char": 21,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 20,
+      "text": "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a"
     },
     {
-      "text": "Deir el - Bahari",
-      "start": 87,
-      "end": 101,
+      "entity_text": "Deir el - Bahari",
+      "start_char": 87,
+      "end_char": 101,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q373909",
         "description": "archaeological site"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 20,
+      "text": "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a"
     },
     {
-      "text": "Drovetti",
-      "start": 121,
-      "end": 129,
+      "entity_text": "Drovetti",
+      "start_char": 121,
+      "end_char": 129,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 20,
+      "text": "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a"
     }
   ],
   [
     {
-      "text": "Khonsu",
-      "start": 10,
-      "end": 16,
+      "entity_text": "Khonsu",
+      "start_char": 10,
+      "end_char": 16,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q190521",
         "description": "Egyptian deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 21,
+      "text": "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 71,
-      "end": 85,
+      "entity_text": "Deir el - Medina",
+      "start_char": 71,
+      "end_char": 85,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 21,
+      "text": "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915"
     }
   ],
   [
     {
-      "text": "Drovetti",
-      "start": 62,
-      "end": 70,
+      "entity_text": "Drovetti",
+      "start_char": 62,
+      "end_char": 70,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 22,
+      "text": "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100"
     }
   ],
   [
     {
-      "text": "Tuthmosis III",
-      "start": 35,
-      "end": 48,
+      "entity_text": "Tuthmosis III",
+      "start_char": 35,
+      "end_char": 48,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157899",
         "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 23,
+      "text": "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti "
     },
     {
-      "text": "Djehuty",
-      "start": 147,
-      "end": 154,
+      "entity_text": "Djehuty",
+      "start_char": 147,
+      "end_char": 154,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q912046",
         "description": "general under the ancient Egyptian king Thutmose III (reigned 1479–1425 BC) in the 18th Dynasty, main hero of the tale of the tale \"The Taking of Joppa\""
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 23,
+      "text": "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti "
     },
     {
-      "text": "Tuthmosi III",
-      "start": 213,
-      "end": 225,
+      "entity_text": "Tuthmosi III",
+      "start_char": 213,
+      "end_char": 225,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157899",
         "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 23,
+      "text": "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti "
     },
     {
-      "text": "Drovetti",
-      "start": 245,
-      "end": 253,
+      "entity_text": "Drovetti",
+      "start_char": 245,
+      "end_char": 253,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 23,
+      "text": "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti "
     }
   ],
   [
     {
-      "text": "Amennakht",
-      "start": 13,
-      "end": 22,
-      "gold_label": "PERSON"
+      "entity_text": "Amennakht",
+      "start_char": 13,
+      "end_char": 22,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 24,
+      "text": "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325"
     },
     {
-      "text": "Drovetti",
-      "start": 83,
-      "end": 91,
+      "entity_text": "Drovetti",
+      "start_char": 83,
+      "end_char": 91,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 24,
+      "text": "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325"
     }
   ],
   [
     {
-      "text": "Wadjren",
-      "start": 22,
-      "end": 29,
-      "gold_label": "PERSON"
+      "entity_text": "Wadjren",
+      "start_char": 22,
+      "end_char": 29,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 25,
+      "text": "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b"
     }
   ],
   [
     {
-      "text": "Cyprus",
-      "start": 55,
-      "end": 61,
+      "entity_text": "Cyprus",
+      "start_char": 55,
+      "end_char": 61,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q229",
         "description": "Mediterranean island country in West Asia"
-      }
+      },
+      "link_id": {
+        "id": 7,
+        "description": "the entity is a location where the artefact was created"
+      },
+      "text_id": 26,
+      "text": "Double juglet of the “Base Ring I” type, imported from Cyprus. Baked clay. New Kingdom, 18th Dynasty (1539-1292 BC).. Acquired before 1888. C. 3673"
     }
   ],
   [],
   [
     {
-      "text": "Amenemope",
-      "start": 19,
-      "end": 28,
+      "entity_text": "Amenemope",
+      "start_char": 19,
+      "end_char": 28,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q2844817",
         "description": "ancient Egyptian writer"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 28,
+      "text": "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347"
     },
     {
-      "text": "Horemheb",
-      "start": 103,
-      "end": 111,
+      "entity_text": "Horemheb",
+      "start_char": 103,
+      "end_char": 111,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157995",
         "description": "final pharaoh of the 18th dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 28,
+      "text": "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347"
     },
     {
-      "text": "Saqqara",
-      "start": 128,
-      "end": 135,
+      "entity_text": "Saqqara",
+      "start_char": 128,
+      "end_char": 135,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q192134",
         "description": "village in Giza Governorate, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 28,
+      "text": "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347"
     },
     {
-      "text": "Drovetti",
-      "start": 142,
-      "end": 150,
+      "entity_text": "Drovetti",
+      "start_char": 142,
+      "end_char": 150,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q822895",
         "description": "Italian diplomat, explorer and scholar"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 28,
+      "text": "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347"
     }
   ],
   [],
@@ -621,2166 +975,3420 @@
   [],
   [
     {
-      "text": "Near Eastern",
-      "start": 17,
-      "end": 29,
-      "gold_label": "LOCATION"
+      "entity_text": "Near Eastern",
+      "start_char": 17,
+      "end_char": 29,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 34,
+      "text": "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238"
     },
     {
-      "text": "Attis",
-      "start": 34,
-      "end": 39,
+      "entity_text": "Attis",
+      "start_char": 34,
+      "end_char": 39,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q262016",
         "description": "Phrygian and Greek mythological figure"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 34,
+      "text": "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238"
     }
   ],
   [],
   [],
   [
     {
-      "text": "Tamit",
-      "start": 161,
-      "end": 166,
-      "gold_label": "LOCATION"
+      "entity_text": "Tamit",
+      "start_char": 161,
+      "end_char": 166,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 37,
+      "text": "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome"
     },
     {
-      "text": "Egyptian Nubia",
-      "start": 168,
-      "end": 182,
-      "gold_label": "LOCATION"
+      "entity_text": "Egyptian Nubia",
+      "start_char": 168,
+      "end_char": 182,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 37,
+      "text": "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome"
     }
   ],
   [],
   [
     {
-      "text": "Tamit",
-      "start": 94,
-      "end": 99,
-      "gold_label": "LOCATION"
+      "entity_text": "Tamit",
+      "start_char": 94,
+      "end_char": 99,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 39,
+      "text": "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645"
     },
     {
-      "text": "Egyptian Nubia",
-      "start": 101,
-      "end": 115,
-      "gold_label": "LOCATION"
+      "entity_text": "Egyptian Nubia",
+      "start_char": 101,
+      "end_char": 115,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 39,
+      "text": "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645"
     },
     {
-      "text": "Nubia",
-      "start": 192,
-      "end": 197,
+      "entity_text": "Nubia",
+      "start_char": 192,
+      "end_char": 197,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q135028",
         "description": "region along the Nile river, which is located in northern Sudan and southern Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 39,
+      "text": "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645"
     }
   ],
   [],
   [],
   [
     {
-      "text": "Nefertum",
-      "start": 25,
-      "end": 33,
+      "entity_text": "Nefertum",
+      "start_char": 25,
+      "end_char": 33,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q464227",
         "description": "Egyptian deity"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 42,
+      "text": "Amulet depicting the god Nefertum"
     }
   ],
   [],
   [
     {
-      "text": "Schiaparelli",
-      "start": 88,
-      "end": 100,
+      "entity_text": "Schiaparelli",
+      "start_char": 88,
+      "end_char": 100,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 44,
+      "text": "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569"
     }
   ],
   [
     {
-      "text": "Schiaparelli",
-      "start": 95,
-      "end": 107,
+      "entity_text": "Schiaparelli",
+      "start_char": 95,
+      "end_char": 107,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 45,
+      "text": "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121"
     }
   ],
   [
     {
-      "text": "Schiaparelli",
-      "start": 94,
-      "end": 106,
+      "entity_text": "Schiaparelli",
+      "start_char": 94,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 46,
+      "text": "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 104,
-      "end": 109,
+      "entity_text": "Asyut",
+      "start_char": 104,
+      "end_char": 109,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 47,
+      "text": "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208"
     },
     {
-      "text": "Schiaparelli",
-      "start": 129,
-      "end": 141,
+      "entity_text": "Schiaparelli",
+      "start_char": 129,
+      "end_char": 141,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 47,
+      "text": "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208"
     }
   ],
   [
     {
-      "text": "Inheretnakht",
-      "start": 9,
-      "end": 21,
-      "gold_label": "PERSON"
+      "entity_text": "Inheretnakht",
+      "start_char": 9,
+      "end_char": 21,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 48,
+      "text": "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264"
     },
     {
-      "text": "Schiaparelli",
-      "start": 108,
-      "end": 120,
+      "entity_text": "Schiaparelli",
+      "start_char": 108,
+      "end_char": 120,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 48,
+      "text": "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264"
     }
   ],
   [
     {
-      "text": "Heliopolis",
-      "start": 81,
-      "end": 91,
+      "entity_text": "Heliopolis",
+      "start_char": 81,
+      "end_char": 91,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q191687",
         "description": "city of ancient Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 49,
+      "text": "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1"
     },
     {
-      "text": "Schiaparelli",
-      "start": 94,
-      "end": 106,
+      "entity_text": "Schiaparelli",
+      "start_char": 94,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 49,
+      "text": "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1"
     }
   ],
   [
     {
-      "text": "Hammamiya",
-      "start": 86,
-      "end": 95,
+      "entity_text": "Hammamiya",
+      "start_char": 86,
+      "end_char": 95,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1604678",
         "description": "human settlement"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 50,
+      "text": "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721"
     },
     {
-      "text": "Schiaparelli",
-      "start": 98,
-      "end": 110,
+      "entity_text": "Schiaparelli",
+      "start_char": 98,
+      "end_char": 110,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 50,
+      "text": "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721"
     }
   ],
   [
     {
-      "text": "Valley of the Queens",
-      "start": 67,
-      "end": 87,
+      "entity_text": "Valley of the Queens",
+      "start_char": 67,
+      "end_char": 87,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q260386",
         "description": "ancient Egyptian necropolis"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 51,
+      "text": "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2"
     },
     {
-      "text": "Schiaparelli",
-      "start": 90,
-      "end": 102,
+      "entity_text": "Schiaparelli",
+      "start_char": 90,
+      "end_char": 102,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 51,
+      "text": "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2"
     }
   ],
   [
     {
-      "text": "African",
-      "start": 37,
-      "end": 44,
+      "entity_text": "African",
+      "start_char": 37,
+      "end_char": 44,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q15",
         "description": "continent"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 52,
+      "text": "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 151,
-      "end": 165,
+      "entity_text": "Deir el - Medina",
+      "start_char": 151,
+      "end_char": 165,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 52,
+      "text": "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295"
     },
     {
-      "text": "Schiaparelli",
-      "start": 168,
-      "end": 180,
+      "entity_text": "Schiaparelli",
+      "start_char": 168,
+      "end_char": 180,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 52,
+      "text": "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 144,
-      "end": 158,
+      "entity_text": "Deir el - Medina",
+      "start_char": 144,
+      "end_char": 158,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 53,
+      "text": "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333"
     },
     {
-      "text": "Schiaparelli",
-      "start": 161,
-      "end": 173,
+      "entity_text": "Schiaparelli",
+      "start_char": 161,
+      "end_char": 173,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 53,
+      "text": "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 64,
-      "end": 78,
+      "entity_text": "Deir el - Medina",
+      "start_char": 64,
+      "end_char": 78,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 54,
+      "text": "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994"
     },
     {
-      "text": "Schiaparelli",
-      "start": 81,
-      "end": 93,
+      "entity_text": "Schiaparelli",
+      "start_char": 81,
+      "end_char": 93,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 54,
+      "text": "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 74,
-      "end": 88,
+      "entity_text": "Deir el - Medina",
+      "start_char": 74,
+      "end_char": 88,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 55,
+      "text": "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013"
     },
     {
-      "text": "Schiaparelli",
-      "start": 91,
-      "end": 103,
+      "entity_text": "Schiaparelli",
+      "start_char": 91,
+      "end_char": 103,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 55,
+      "text": "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 65,
-      "end": 79,
+      "entity_text": "Deir el - Medina",
+      "start_char": 65,
+      "end_char": 79,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 56,
+      "text": "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074"
     },
     {
-      "text": "Schiaparelli",
-      "start": 82,
-      "end": 94,
+      "entity_text": "Schiaparelli",
+      "start_char": 82,
+      "end_char": 94,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 56,
+      "text": "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 72,
-      "end": 86,
+      "entity_text": "Deir el - Medina",
+      "start_char": 72,
+      "end_char": 86,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 57,
+      "text": "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660"
     },
     {
-      "text": "Schiaparelli",
-      "start": 89,
-      "end": 101,
+      "entity_text": "Schiaparelli",
+      "start_char": 89,
+      "end_char": 101,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 57,
+      "text": "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 86,
-      "end": 91,
+      "entity_text": "Asyut",
+      "start_char": 86,
+      "end_char": 91,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 58,
+      "text": "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1"
     },
     {
-      "text": "Djefahapi",
-      "start": 118,
-      "end": 127,
-      "gold_label": "PERSON"
+      "entity_text": "Djefahapi",
+      "start_char": 118,
+      "end_char": 127,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 58,
+      "text": "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1"
     },
     {
-      "text": "Schiaparelli",
-      "start": 137,
-      "end": 149,
+      "entity_text": "Schiaparelli",
+      "start_char": 137,
+      "end_char": 149,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 58,
+      "text": "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 87,
-      "end": 92,
+      "entity_text": "Asyut",
+      "start_char": 87,
+      "end_char": 92,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 59,
+      "text": "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141"
     },
     {
-      "text": "Schiaparelli",
-      "start": 95,
-      "end": 107,
+      "entity_text": "Schiaparelli",
+      "start_char": 95,
+      "end_char": 107,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 59,
+      "text": "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 76,
-      "end": 88,
+      "entity_text": "Amenhotep II",
+      "start_char": 76,
+      "end_char": 88,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 90,
-      "end": 102,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 90,
+      "end_char": 102,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     },
     {
-      "text": "Amenhotep III",
-      "start": 107,
-      "end": 120,
+      "entity_text": "Amenhotep III",
+      "start_char": 107,
+      "end_char": 120,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 137,
-      "end": 151,
+      "entity_text": "Deir el - Medina",
+      "start_char": 137,
+      "end_char": 151,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 153,
-      "end": 164,
+      "entity_text": "Tomb of Kha",
+      "start_char": 153,
+      "end_char": 164,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     },
     {
-      "text": "Schiaparelli",
-      "start": 174,
-      "end": 186,
+      "entity_text": "Schiaparelli",
+      "start_char": 174,
+      "end_char": 186,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 60,
+      "text": "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 87,
-      "end": 99,
+      "entity_text": "Amenhotep II",
+      "start_char": 87,
+      "end_char": 99,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 101,
-      "end": 113,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 101,
+      "end_char": 113,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     },
     {
-      "text": "Amenhotep III",
-      "start": 118,
-      "end": 131,
+      "entity_text": "Amenhotep III",
+      "start_char": 118,
+      "end_char": 131,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 148,
-      "end": 162,
+      "entity_text": "Deir el - Medina",
+      "start_char": 148,
+      "end_char": 162,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 164,
-      "end": 175,
+      "entity_text": "Tomb of Kha",
+      "start_char": 164,
+      "end_char": 175,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     },
     {
-      "text": "Schiaparelli",
-      "start": 185,
-      "end": 197,
+      "entity_text": "Schiaparelli",
+      "start_char": 185,
+      "end_char": 197,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 61,
+      "text": "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 81,
-      "end": 93,
+      "entity_text": "Amenhotep II",
+      "start_char": 81,
+      "end_char": 93,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 95,
-      "end": 107,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 95,
+      "end_char": 107,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     },
     {
-      "text": "Amenhotep III",
-      "start": 112,
-      "end": 125,
+      "entity_text": "Amenhotep III",
+      "start_char": 112,
+      "end_char": 125,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 142,
-      "end": 156,
+      "entity_text": "Deir el - Medina",
+      "start_char": 142,
+      "end_char": 156,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 158,
-      "end": 169,
+      "entity_text": "Tomb of Kha",
+      "start_char": 158,
+      "end_char": 169,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     },
     {
-      "text": "Schiaparelli",
-      "start": 179,
-      "end": 191,
+      "entity_text": "Schiaparelli",
+      "start_char": 179,
+      "end_char": 191,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 62,
+      "text": "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 71,
-      "end": 83,
+      "entity_text": "Amenhotep II",
+      "start_char": 71,
+      "end_char": 83,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 85,
-      "end": 97,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 85,
+      "end_char": 97,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     },
     {
-      "text": "Amenhotep III",
-      "start": 102,
-      "end": 115,
+      "entity_text": "Amenhotep III",
+      "start_char": 102,
+      "end_char": 115,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 132,
-      "end": 146,
+      "entity_text": "Deir el - Medina",
+      "start_char": 132,
+      "end_char": 146,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 148,
-      "end": 159,
+      "entity_text": "Tomb of Kha",
+      "start_char": 148,
+      "end_char": 159,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     },
     {
-      "text": "Schiaparelli",
-      "start": 169,
-      "end": 181,
+      "entity_text": "Schiaparelli",
+      "start_char": 169,
+      "end_char": 181,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 63,
+      "text": "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 65,
-      "end": 77,
+      "entity_text": "Amenhotep II",
+      "start_char": 65,
+      "end_char": 77,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 79,
-      "end": 91,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 79,
+      "end_char": 91,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     },
     {
-      "text": "Amenhotep III",
-      "start": 96,
-      "end": 109,
+      "entity_text": "Amenhotep III",
+      "start_char": 96,
+      "end_char": 109,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 126,
-      "end": 140,
+      "entity_text": "Deir el - Medina",
+      "start_char": 126,
+      "end_char": 140,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 142,
-      "end": 153,
+      "entity_text": "Tomb of Kha",
+      "start_char": 142,
+      "end_char": 153,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     },
     {
-      "text": "Schiaparelli",
-      "start": 163,
-      "end": 175,
+      "entity_text": "Schiaparelli",
+      "start_char": 163,
+      "end_char": 175,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 64,
+      "text": "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 54,
-      "end": 66,
+      "entity_text": "Amenhotep II",
+      "start_char": 54,
+      "end_char": 66,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 68,
-      "end": 80,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 68,
+      "end_char": 80,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     },
     {
-      "text": "Amenhotep III",
-      "start": 85,
-      "end": 98,
+      "entity_text": "Amenhotep III",
+      "start_char": 85,
+      "end_char": 98,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 115,
-      "end": 129,
+      "entity_text": "Deir el - Medina",
+      "start_char": 115,
+      "end_char": 129,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 131,
-      "end": 142,
+      "entity_text": "Tomb of Kha",
+      "start_char": 131,
+      "end_char": 142,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     },
     {
-      "text": "Schiaparelli",
-      "start": 152,
-      "end": 164,
+      "entity_text": "Schiaparelli",
+      "start_char": 152,
+      "end_char": 164,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 65,
+      "text": "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 108,
-      "end": 120,
+      "entity_text": "Amenhotep II",
+      "start_char": 108,
+      "end_char": 120,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 122,
-      "end": 134,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 122,
+      "end_char": 134,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     },
     {
-      "text": "Amenhotep III",
-      "start": 139,
-      "end": 152,
+      "entity_text": "Amenhotep III",
+      "start_char": 139,
+      "end_char": 152,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 169,
-      "end": 183,
+      "entity_text": "Deir el - Medina",
+      "start_char": 169,
+      "end_char": 183,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 185,
-      "end": 196,
+      "entity_text": "Tomb of Kha",
+      "start_char": 185,
+      "end_char": 196,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     },
     {
-      "text": "Schiaparelli",
-      "start": 206,
-      "end": 218,
+      "entity_text": "Schiaparelli",
+      "start_char": 206,
+      "end_char": 218,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 66,
+      "text": "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 69,
-      "end": 81,
+      "entity_text": "Amenhotep II",
+      "start_char": 69,
+      "end_char": 81,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 83,
-      "end": 95,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 83,
+      "end_char": 95,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     },
     {
-      "text": "Amenhotep III",
-      "start": 100,
-      "end": 113,
+      "entity_text": "Amenhotep III",
+      "start_char": 100,
+      "end_char": 113,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 130,
-      "end": 144,
+      "entity_text": "Deir el - Medina",
+      "start_char": 130,
+      "end_char": 144,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 146,
-      "end": 157,
+      "entity_text": "Tomb of Kha",
+      "start_char": 146,
+      "end_char": 157,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     },
     {
-      "text": "Schiaparelli",
-      "start": 167,
-      "end": 179,
+      "entity_text": "Schiaparelli",
+      "start_char": 167,
+      "end_char": 179,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 67,
+      "text": "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424"
     }
   ],
   [
     {
-      "text": "Kha",
-      "start": 16,
-      "end": 19,
-      "gold_label": "PERSON"
+      "entity_text": "Kha",
+      "start_char": 16,
+      "end_char": 19,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Amenhotep II",
-      "start": 93,
-      "end": 105,
+      "entity_text": "Amenhotep II",
+      "start_char": 93,
+      "end_char": 105,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 107,
-      "end": 119,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 107,
+      "end_char": 119,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Amenhotep III",
-      "start": 124,
-      "end": 137,
+      "entity_text": "Amenhotep III",
+      "start_char": 124,
+      "end_char": 137,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 154,
-      "end": 168,
+      "entity_text": "Deir el - Medina",
+      "start_char": 154,
+      "end_char": 168,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 170,
-      "end": 181,
+      "entity_text": "Tomb of Kha",
+      "start_char": 170,
+      "end_char": 181,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     },
     {
-      "text": "Schiaparelli",
-      "start": 191,
-      "end": 203,
+      "entity_text": "Schiaparelli",
+      "start_char": 191,
+      "end_char": 203,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 68,
+      "text": "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 77,
-      "end": 89,
+      "entity_text": "Amenhotep II",
+      "start_char": 77,
+      "end_char": 89,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 91,
-      "end": 103,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 91,
+      "end_char": 103,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     },
     {
-      "text": "Amenhotep III",
-      "start": 108,
-      "end": 121,
+      "entity_text": "Amenhotep III",
+      "start_char": 108,
+      "end_char": 121,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 138,
-      "end": 152,
+      "entity_text": "Deir el - Medina",
+      "start_char": 138,
+      "end_char": 152,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 154,
-      "end": 165,
+      "entity_text": "Tomb of Kha",
+      "start_char": 154,
+      "end_char": 165,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     },
     {
-      "text": "Schiaparelli",
-      "start": 175,
-      "end": 187,
+      "entity_text": "Schiaparelli",
+      "start_char": 175,
+      "end_char": 187,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 69,
+      "text": "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 92,
-      "end": 104,
+      "entity_text": "Amenhotep II",
+      "start_char": 92,
+      "end_char": 104,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 106,
-      "end": 118,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 106,
+      "end_char": 118,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     },
     {
-      "text": "Amenhotep III",
-      "start": 123,
-      "end": 136,
+      "entity_text": "Amenhotep III",
+      "start_char": 123,
+      "end_char": 136,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 153,
-      "end": 167,
+      "entity_text": "Deir el - Medina",
+      "start_char": 153,
+      "end_char": 167,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 169,
-      "end": 180,
+      "entity_text": "Tomb of Kha",
+      "start_char": 169,
+      "end_char": 180,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     },
     {
-      "text": "Schiaparelli",
-      "start": 190,
-      "end": 202,
+      "entity_text": "Schiaparelli",
+      "start_char": 190,
+      "end_char": 202,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 70,
+      "text": "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606"
     }
   ],
   [
     {
-      "text": "Amenhotep II",
-      "start": 55,
-      "end": 67,
+      "entity_text": "Amenhotep II",
+      "start_char": 55,
+      "end_char": 67,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q158052",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     },
     {
-      "text": "Tuthmosis IV",
-      "start": 69,
-      "end": 81,
+      "entity_text": "Tuthmosis IV",
+      "start_char": 69,
+      "end_char": 81,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157985",
         "description": "Egyptian Pharaoh of the 18th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     },
     {
-      "text": "Amenhotep III",
-      "start": 86,
-      "end": 99,
+      "entity_text": "Amenhotep III",
+      "start_char": 86,
+      "end_char": 99,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q42606",
         "description": "ninth Pharaoh of the Eighteenth dynasty of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 116,
-      "end": 130,
+      "entity_text": "Deir el - Medina",
+      "start_char": 116,
+      "end_char": 130,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     },
     {
-      "text": "Tomb of Kha",
-      "start": 132,
-      "end": 143,
+      "entity_text": "Tomb of Kha",
+      "start_char": 132,
+      "end_char": 143,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q744424",
         "description": "ancient Egyptian tomb"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     },
     {
-      "text": "Schiaparelli",
-      "start": 153,
-      "end": 165,
+      "entity_text": "Schiaparelli",
+      "start_char": 153,
+      "end_char": 165,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 71,
+      "text": "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10"
     }
   ],
   [
     {
-      "text": "Sesostris I",
-      "start": 56,
-      "end": 67,
+      "entity_text": "Sesostris I",
+      "start_char": 56,
+      "end_char": 67,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q18763",
         "description": "pharaoh of Egypt"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 72,
+      "text": "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676"
     },
     {
-      "text": "Asyut",
-      "start": 84,
-      "end": 89,
+      "entity_text": "Asyut",
+      "start_char": 84,
+      "end_char": 89,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 72,
+      "text": "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676"
     },
     {
-      "text": "Tomb of Shemes",
-      "start": 91,
-      "end": 105,
+      "entity_text": "Tomb of Shemes",
+      "start_char": 91,
+      "end_char": 105,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q134283912",
         "description": "ancient egyptian tomb in Asyut, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 72,
+      "text": "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676"
     },
     {
-      "text": "Schiaparelli",
-      "start": 108,
-      "end": 120,
+      "entity_text": "Schiaparelli",
+      "start_char": 108,
+      "end_char": 120,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 72,
+      "text": "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 68,
-      "end": 73,
+      "entity_text": "Asyut",
+      "start_char": 68,
+      "end_char": 73,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 73,
+      "text": "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812"
     },
     {
-      "text": "Tomb of Minhotep",
-      "start": 75,
-      "end": 91,
+      "entity_text": "Tomb of Minhotep",
+      "start_char": 75,
+      "end_char": 91,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q134283924",
         "description": "ancient egyptian tomb in Asyut, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 73,
+      "text": "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812"
     },
     {
-      "text": "Schiaparelli",
-      "start": 94,
-      "end": 106,
+      "entity_text": "Schiaparelli",
+      "start_char": 94,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 73,
+      "text": "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 68,
-      "end": 73,
+      "entity_text": "Asyut",
+      "start_char": 68,
+      "end_char": 73,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 74,
+      "text": "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853"
     },
     {
-      "text": "Tomb of Minhotep",
-      "start": 75,
-      "end": 91,
+      "entity_text": "Tomb of Minhotep",
+      "start_char": 75,
+      "end_char": 91,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q134283924",
         "description": "ancient egyptian tomb in Asyut, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 74,
+      "text": "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853"
     },
     {
-      "text": "Schiaparelli",
-      "start": 94,
-      "end": 106,
+      "entity_text": "Schiaparelli",
+      "start_char": 94,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 74,
+      "text": "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853"
     }
   ],
   [
     {
-      "text": "Menna",
-      "start": 59,
-      "end": 64,
+      "entity_text": "Menna",
+      "start_char": 59,
+      "end_char": 64,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q6817163",
         "description": "ancient Egyptian scribe"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 75,
+      "text": "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381"
     },
     {
-      "text": "Ramesses III",
-      "start": 113,
-      "end": 125,
+      "entity_text": "Ramesses III",
+      "start_char": 113,
+      "end_char": 125,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1528",
         "description": "Egyptian pharaoh of the 20th dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 75,
+      "text": "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 142,
-      "end": 156,
+      "entity_text": "Deir el - Medina",
+      "start_char": 142,
+      "end_char": 156,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 75,
+      "text": "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381"
     },
     {
-      "text": "Schiaparelli",
-      "start": 159,
-      "end": 171,
+      "entity_text": "Schiaparelli",
+      "start_char": 159,
+      "end_char": 171,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 75,
+      "text": "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381"
     }
   ],
   [
     {
-      "text": "Deir el - Medina",
-      "start": 74,
-      "end": 88,
+      "entity_text": "Deir el - Medina",
+      "start_char": 74,
+      "end_char": 88,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 76,
+      "text": "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965"
     },
     {
-      "text": "Schiaparelli",
-      "start": 91,
-      "end": 103,
+      "entity_text": "Schiaparelli",
+      "start_char": 91,
+      "end_char": 103,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 76,
+      "text": "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965"
     }
   ],
   [
     {
-      "text": "Nespayherhat",
-      "start": 10,
-      "end": 22,
-      "gold_label": "PERSON"
+      "entity_text": "Nespayherhat",
+      "start_char": 10,
+      "end_char": 22,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 77,
+      "text": "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437"
     },
     {
-      "text": "Deir el - Medina",
-      "start": 97,
-      "end": 111,
+      "entity_text": "Deir el - Medina",
+      "start_char": 97,
+      "end_char": 111,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q750212",
         "description": "ancient Egyptian village in the Valley of the Kings"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 77,
+      "text": "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437"
     },
     {
-      "text": "Schiaparelli",
-      "start": 114,
-      "end": 126,
+      "entity_text": "Schiaparelli",
+      "start_char": 114,
+      "end_char": 126,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 77,
+      "text": "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437"
     }
   ],
   [
     {
-      "text": "Asyut",
-      "start": 109,
-      "end": 114,
+      "entity_text": "Asyut",
+      "start_char": 109,
+      "end_char": 114,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q29962",
         "description": "City in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 78,
+      "text": "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029"
     },
     {
-      "text": "Schiaparelli",
-      "start": 117,
-      "end": 129,
+      "entity_text": "Schiaparelli",
+      "start_char": 117,
+      "end_char": 129,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 78,
+      "text": "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 89,
-      "end": 97,
+      "entity_text": "Gebelein",
+      "start_char": 89,
+      "end_char": 97,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 79,
+      "text": "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2"
     },
     {
-      "text": "Schiaparelli",
-      "start": 100,
-      "end": 112,
+      "entity_text": "Schiaparelli",
+      "start_char": 100,
+      "end_char": 112,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 79,
+      "text": "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 90,
-      "end": 98,
+      "entity_text": "Gebelein",
+      "start_char": 90,
+      "end_char": 98,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 80,
+      "text": "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170"
     },
     {
-      "text": "Schiaparelli",
-      "start": 101,
-      "end": 113,
+      "entity_text": "Schiaparelli",
+      "start_char": 101,
+      "end_char": 113,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 80,
+      "text": "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170"
     }
   ],
   [
     {
-      "text": "Tuthmosis III",
-      "start": 40,
-      "end": 53,
+      "entity_text": "Tuthmosis III",
+      "start_char": 40,
+      "end_char": 53,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157899",
         "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Hathor",
-      "start": 66,
-      "end": 72,
+      "entity_text": "Hathor",
+      "start_char": 66,
+      "end_char": 72,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q133343",
         "description": "major goddess in ancient Egyptian religion"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Gebelein",
-      "start": 86,
-      "end": 94,
+      "entity_text": "Gebelein",
+      "start_char": 86,
+      "end_char": 94,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Tuthmosis III",
-      "start": 125,
-      "end": 138,
+      "entity_text": "Tuthmosis III",
+      "start_char": 125,
+      "end_char": 138,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q157899",
         "description": "sixth Egyptian Pharaoh of the Eighteenth Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Gebelein",
-      "start": 155,
-      "end": 163,
+      "entity_text": "Gebelein",
+      "start_char": 155,
+      "end_char": 163,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Hathor",
-      "start": 175,
-      "end": 181,
+      "entity_text": "Hathor",
+      "start_char": 175,
+      "end_char": 181,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q133343",
         "description": "major goddess in ancient Egyptian religion"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     },
     {
-      "text": "Schiaparelli",
-      "start": 207,
-      "end": 219,
+      "entity_text": "Schiaparelli",
+      "start_char": 207,
+      "end_char": 219,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 81,
+      "text": "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 68,
-      "end": 76,
+      "entity_text": "Gebelein",
+      "start_char": 68,
+      "end_char": 76,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 82,
+      "text": "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054"
     },
     {
-      "text": "Iti",
-      "start": 86,
-      "end": 89,
+      "entity_text": "Iti",
+      "start_char": 86,
+      "end_char": 89,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 82,
+      "text": "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054"
     },
     {
-      "text": "Neferu",
-      "start": 94,
-      "end": 100,
+      "entity_text": "Neferu",
+      "start_char": 94,
+      "end_char": 100,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 82,
+      "text": "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054"
     },
     {
-      "text": "Schiaparelli",
-      "start": 103,
-      "end": 115,
+      "entity_text": "Schiaparelli",
+      "start_char": 103,
+      "end_char": 115,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 82,
+      "text": "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 70,
-      "end": 78,
+      "entity_text": "Gebelein",
+      "start_char": 70,
+      "end_char": 78,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 83,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066"
     },
     {
-      "text": "Iti",
-      "start": 88,
-      "end": 91,
+      "entity_text": "Iti",
+      "start_char": 88,
+      "end_char": 91,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 83,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066"
     },
     {
-      "text": "Neferu",
-      "start": 96,
-      "end": 102,
+      "entity_text": "Neferu",
+      "start_char": 96,
+      "end_char": 102,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 83,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066"
     },
     {
-      "text": "Schiaparelli",
-      "start": 105,
-      "end": 117,
+      "entity_text": "Schiaparelli",
+      "start_char": 105,
+      "end_char": 117,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 83,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 7,
-      "end": 15,
+      "entity_text": "Gebelein",
+      "start_char": 7,
+      "end_char": 15,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 84,
+      "text": "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084"
     },
     {
-      "text": "Iti",
-      "start": 25,
-      "end": 28,
+      "entity_text": "Iti",
+      "start_char": 25,
+      "end_char": 28,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 84,
+      "text": "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084"
     },
     {
-      "text": "Neferu",
-      "start": 33,
-      "end": 39,
+      "entity_text": "Neferu",
+      "start_char": 33,
+      "end_char": 39,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 84,
+      "text": "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084"
     },
     {
-      "text": "Schiaparelli",
-      "start": 42,
-      "end": 54,
+      "entity_text": "Schiaparelli",
+      "start_char": 42,
+      "end_char": 54,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 84,
+      "text": "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 71,
-      "end": 79,
+      "entity_text": "Gebelein",
+      "start_char": 71,
+      "end_char": 79,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 85,
+      "text": "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108"
     },
     {
-      "text": "Iti",
-      "start": 89,
-      "end": 92,
+      "entity_text": "Iti",
+      "start_char": 89,
+      "end_char": 92,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 85,
+      "text": "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108"
     },
     {
-      "text": "Neferu",
-      "start": 97,
-      "end": 103,
+      "entity_text": "Neferu",
+      "start_char": 97,
+      "end_char": 103,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 85,
+      "text": "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108"
     },
     {
-      "text": "Schiaparelli",
-      "start": 106,
-      "end": 118,
+      "entity_text": "Schiaparelli",
+      "start_char": 106,
+      "end_char": 118,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 85,
+      "text": "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 52,
-      "end": 60,
+      "entity_text": "Gebelein",
+      "start_char": 52,
+      "end_char": 60,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 86,
+      "text": "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111"
     },
     {
-      "text": "Iti",
-      "start": 87,
-      "end": 90,
+      "entity_text": "Iti",
+      "start_char": 87,
+      "end_char": 90,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 86,
+      "text": "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111"
     },
     {
-      "text": "Neferu",
-      "start": 95,
-      "end": 101,
+      "entity_text": "Neferu",
+      "start_char": 95,
+      "end_char": 101,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 86,
+      "text": "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111"
     },
     {
-      "text": "Schiaparelli",
-      "start": 104,
-      "end": 116,
+      "entity_text": "Schiaparelli",
+      "start_char": 104,
+      "end_char": 116,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 86,
+      "text": "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 59,
-      "end": 67,
+      "entity_text": "Gebelein",
+      "start_char": 59,
+      "end_char": 67,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 87,
+      "text": "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165"
     },
     {
-      "text": "Iti",
-      "start": 77,
-      "end": 80,
+      "entity_text": "Iti",
+      "start_char": 77,
+      "end_char": 80,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 87,
+      "text": "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165"
     },
     {
-      "text": "Neferu",
-      "start": 85,
-      "end": 91,
+      "entity_text": "Neferu",
+      "start_char": 85,
+      "end_char": 91,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 87,
+      "text": "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165"
     },
     {
-      "text": "Schiaparelli",
-      "start": 94,
-      "end": 106,
+      "entity_text": "Schiaparelli",
+      "start_char": 94,
+      "end_char": 106,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 87,
+      "text": "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 60,
-      "end": 68,
+      "entity_text": "Gebelein",
+      "start_char": 60,
+      "end_char": 68,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 88,
+      "text": "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254"
     },
     {
-      "text": "Iti",
-      "start": 78,
-      "end": 81,
+      "entity_text": "Iti",
+      "start_char": 78,
+      "end_char": 81,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 88,
+      "text": "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254"
     },
     {
-      "text": "Neferu",
-      "start": 86,
-      "end": 92,
+      "entity_text": "Neferu",
+      "start_char": 86,
+      "end_char": 92,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 88,
+      "text": "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254"
     },
     {
-      "text": "Schiaparelli",
-      "start": 95,
-      "end": 107,
+      "entity_text": "Schiaparelli",
+      "start_char": 95,
+      "end_char": 107,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 88,
+      "text": "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 70,
-      "end": 78,
+      "entity_text": "Gebelein",
+      "start_char": 70,
+      "end_char": 78,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 89,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255"
     },
     {
-      "text": "Iti",
-      "start": 88,
-      "end": 91,
+      "entity_text": "Iti",
+      "start_char": 88,
+      "end_char": 91,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 89,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255"
     },
     {
-      "text": "Neferu",
-      "start": 96,
-      "end": 102,
+      "entity_text": "Neferu",
+      "start_char": 96,
+      "end_char": 102,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 89,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255"
     },
     {
-      "text": "Schiaparelli",
-      "start": 105,
-      "end": 117,
+      "entity_text": "Schiaparelli",
+      "start_char": 105,
+      "end_char": 117,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 89,
+      "text": "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255"
     }
   ],
   [
     {
-      "text": "Ini",
-      "start": 9,
-      "end": 12,
+      "entity_text": "Ini",
+      "start_char": 9,
+      "end_char": 12,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q325744",
         "description": "Egyptian pharaoh"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 90,
+      "text": "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268"
     },
     {
-      "text": "Gebelein",
-      "start": 78,
-      "end": 86,
+      "entity_text": "Gebelein",
+      "start_char": 78,
+      "end_char": 86,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 90,
+      "text": "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268"
     },
     {
-      "text": "Northern Cemetery",
-      "start": 88,
-      "end": 105,
-      "gold_label": "LOCATION"
+      "entity_text": "Northern Cemetery",
+      "start_char": 88,
+      "end_char": 105,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 90,
+      "text": "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268"
     },
     {
-      "text": "Tomb of Ini",
-      "start": 107,
-      "end": 118,
+      "entity_text": "Tomb of Ini",
+      "start_char": 107,
+      "end_char": 118,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q125489574",
         "description": "ancient Egyptian tomb in Gebelein, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 90,
+      "text": "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268"
     },
     {
-      "text": "Schiaparelli",
-      "start": 121,
-      "end": 133,
+      "entity_text": "Schiaparelli",
+      "start_char": 121,
+      "end_char": 133,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 90,
+      "text": "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 58,
-      "end": 66,
+      "entity_text": "Gebelein",
+      "start_char": 58,
+      "end_char": 66,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 91,
+      "text": "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991"
     },
     {
-      "text": "Tomba Grande",
-      "start": 69,
-      "end": 81,
-      "gold_label": "LOCATION"
+      "entity_text": "Tomba Grande",
+      "start_char": 69,
+      "end_char": 81,
+      "gold_label": "LOCATION",
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 91,
+      "text": "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991"
     },
     {
-      "text": "Schiaparelli",
-      "start": 85,
-      "end": 97,
+      "entity_text": "Schiaparelli",
+      "start_char": 85,
+      "end_char": 97,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 91,
+      "text": "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991"
     }
   ],
   [
     {
-      "text": "Iti",
-      "start": 15,
-      "end": 18,
+      "entity_text": "Iti",
+      "start_char": 15,
+      "end_char": 18,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 1,
+        "description": "the entity is a person depicted on or by the artefact"
+      },
+      "text_id": 92,
+      "text": "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01"
     },
     {
-      "text": "Gebelein",
-      "start": 113,
-      "end": 121,
+      "entity_text": "Gebelein",
+      "start_char": 113,
+      "end_char": 121,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 92,
+      "text": "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01"
     },
     {
-      "text": "Iti",
-      "start": 131,
-      "end": 134,
+      "entity_text": "Iti",
+      "start_char": 131,
+      "end_char": 134,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 92,
+      "text": "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01"
     },
     {
-      "text": "Neferu",
-      "start": 139,
-      "end": 145,
+      "entity_text": "Neferu",
+      "start_char": 139,
+      "end_char": 145,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 92,
+      "text": "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01"
     },
     {
-      "text": "Schiaparelli",
-      "start": 148,
-      "end": 160,
+      "entity_text": "Schiaparelli",
+      "start_char": 148,
+      "end_char": 160,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 92,
+      "text": "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01"
     }
   ],
   [
     {
-      "text": "Gebelein",
-      "start": 137,
-      "end": 145,
+      "entity_text": "Gebelein",
+      "start_char": 137,
+      "end_char": 145,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 93,
+      "text": "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12"
     },
     {
-      "text": "Iti",
-      "start": 155,
-      "end": 158,
+      "entity_text": "Iti",
+      "start_char": 155,
+      "end_char": 158,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q152375",
         "description": "ancient Egyptian pharaoh of the First Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 93,
+      "text": "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12"
     },
     {
-      "text": "Neferu",
-      "start": 163,
-      "end": 169,
+      "entity_text": "Neferu",
+      "start_char": 163,
+      "end_char": 169,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q849695",
         "description": "Egyptian queen consort"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 93,
+      "text": "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12"
     },
     {
-      "text": "Schiaparelli",
-      "start": 172,
-      "end": 184,
+      "entity_text": "Schiaparelli",
+      "start_char": 172,
+      "end_char": 184,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 93,
+      "text": "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12"
     }
   ],
   [
     {
-      "text": "Perim",
-      "start": 18,
-      "end": 23,
-      "gold_label": "PERSON"
+      "entity_text": "Perim",
+      "start_char": 18,
+      "end_char": 23,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 94,
+      "text": "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736"
     },
     {
-      "text": "Shepset",
-      "start": 28,
-      "end": 35,
+      "entity_text": "Shepset",
+      "start_char": 28,
+      "end_char": 35,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q84959355",
         "description": "ancient Egyptian princess"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 94,
+      "text": "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736"
     },
     {
-      "text": "Gebelein",
-      "start": 89,
-      "end": 97,
+      "entity_text": "Gebelein",
+      "start_char": 89,
+      "end_char": 97,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1496830",
         "description": "village and archaeological site in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 94,
+      "text": "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736"
     },
     {
-      "text": "Perim",
-      "start": 110,
-      "end": 115,
-      "gold_label": "PERSON"
+      "entity_text": "Perim",
+      "start_char": 110,
+      "end_char": 115,
+      "gold_label": "PERSON",
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 94,
+      "text": "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736"
     },
     {
-      "text": "Schiaparelli",
-      "start": 118,
-      "end": 130,
+      "entity_text": "Schiaparelli",
+      "start_char": 118,
+      "end_char": 130,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 94,
+      "text": "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736"
     }
   ],
   [
     {
-      "text": "Fayum",
-      "start": 83,
-      "end": 88,
+      "entity_text": "Fayum",
+      "start_char": 83,
+      "end_char": 88,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q203299",
         "description": "city in Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 95,
+      "text": "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134"
     },
     {
-      "text": "Hawara",
-      "start": 90,
-      "end": 96,
+      "entity_text": "Hawara",
+      "start_char": 90,
+      "end_char": 96,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q26237",
         "description": "necropolis in Faiyum Governorate, Egypt"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 95,
+      "text": "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134"
     }
   ],
   [
     {
-      "text": "Schiaparelli",
-      "start": 138,
-      "end": 150,
+      "entity_text": "Schiaparelli",
+      "start_char": 138,
+      "end_char": 150,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q1356829",
         "description": "Italian egyptologist (1856-1928)"
-      }
+      },
+      "link_id": {
+        "id": 4,
+        "description": "the entity is a person that owned the artefact"
+      },
+      "text_id": 96,
+      "text": "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486"
     }
   ],
   [
     {
-      "text": "Akhenaten",
-      "start": 56,
-      "end": 65,
+      "entity_text": "Akhenaten",
+      "start_char": 56,
+      "end_char": 65,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q81794",
         "description": "Egyptian pharaoh in 18th Dynasty"
-      }
+      },
+      "link_id": {
+        "id": 5,
+        "description": "the entity is a person in power during the period of the creation of the artefact"
+      },
+      "text_id": 97,
+      "text": "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143"
     },
     {
-      "text": "Munich",
-      "start": 96,
-      "end": 102,
+      "entity_text": "Munich",
+      "start_char": 96,
+      "end_char": 102,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1726",
         "description": "capital and most populous city of Bavaria, Germany"
-      }
+      },
+      "link_id": {
+        "id": 11,
+        "description": "other entity type or other relation between entity and artefact"
+      },
+      "text_id": 97,
+      "text": "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143"
     }
   ],
   [
     {
-      "text": "Tebtynis",
-      "start": 58,
-      "end": 66,
+      "entity_text": "Tebtynis",
+      "start_char": 58,
+      "end_char": 66,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1500580",
         "description": "archaeological site in the Egyptian depression of el-Faiyum"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 98,
+      "text": "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03"
     },
     {
-      "text": "Anti",
-      "start": 69,
-      "end": 73,
+      "entity_text": "Anti",
+      "start_char": 69,
+      "end_char": 73,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q3659000",
         "description": "Italian archaeologist (1889-1961)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 98,
+      "text": "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03"
     },
     {
-      "text": "Bagnani",
-      "start": 78,
-      "end": 85,
+      "entity_text": "Bagnani",
+      "start_char": 78,
+      "end_char": 85,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q21524761",
         "description": "Italian-born Canadian classical archaeologist and historian (1900-1985)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 98,
+      "text": "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03"
     }
   ],
   [
     {
-      "text": "Tebtynis",
-      "start": 111,
-      "end": 119,
+      "entity_text": "Tebtynis",
+      "start_char": 111,
+      "end_char": 119,
       "gold_label": "LOCATION",
       "wikidata_id": {
         "id": "Q1500580",
         "description": "archaeological site in the Egyptian depression of el-Faiyum"
-      }
+      },
+      "link_id": {
+        "id": 9,
+        "description": "the entity is a location where the artefact was discovered"
+      },
+      "text_id": 99,
+      "text": "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691"
     },
     {
-      "text": "Anti",
-      "start": 123,
-      "end": 127,
+      "entity_text": "Anti",
+      "start_char": 123,
+      "end_char": 127,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q3659000",
         "description": "Italian archaeologist (1889-1961)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 99,
+      "text": "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691"
     },
     {
-      "text": "Bagnani",
-      "start": 132,
-      "end": 139,
+      "entity_text": "Bagnani",
+      "start_char": 132,
+      "end_char": 139,
       "gold_label": "PERSON",
       "wikidata_id": {
         "id": "Q21524761",
         "description": "Italian-born Canadian classical archaeologist and historian (1900-1985)"
-      }
+      },
+      "link_id": {
+        "id": 3,
+        "description": "the entity is a person that discovered the artefact"
+      },
+      "text_id": 99,
+      "text": "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691"
     }
   ]
 ]

--- a/notebooks/tasks/linking_cache.json
+++ b/notebooks/tasks/linking_cache.json
@@ -1,1201 +1,1458 @@
 {
-  "Anubis": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
-      "gpt-4o-mini": "1",
-      "qwen3:0.6b": "1"
-    }
-  },
-  "Sekhmet": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "gpt-4o-mini": "1",
-      "qwen3:0.6b": "6"
-    }
-  },
-  "Thebes": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "gpt-4o-mini": "7.",
-      "qwen3:0.6b": "6",
-      "qwen3:8b": "7"
-    },
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": "7"
-    },
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": "7"
-    },
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Amenhotep III": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+  "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
+    "Amenhotep III": {
       "gpt-4o-mini": "5",
       "qwen3:0.6b": "5. the entity is a person that in power during the period of the creation of the artefact",
       "qwen3:8b": "5"
     },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": "5"
+    "Thebes": {
+      "gpt-4o-mini": "7.",
+      "qwen3:0.6b": "6",
+      "qwen3:8b": "7"
     },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "5"
+    "Drovetti": {
+      "qwen3:8b": "4"
     },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "5"
+    "Sekhmet": {
+      "gpt-4o-mini": "1",
+      "qwen3:0.6b": "6"
     },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "5"
+    "Tom": {
+      "qwen3:0.6b": "6"
     },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": "5"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "5"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "5"
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": "5"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "5"
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "5"
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": "5"
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": "5"
+    "New York": {
+      "qwen3:0.6b": "6"
     }
   },
-  "Bastet": {
-    "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
+  "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
+    "Drovetti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Bastet": {
       "gpt-4o-mini": "1"
     }
   },
-  "Drovetti": {
-    "Statuette of the goddess Bastet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 271": {
-      "gpt-4o-mini": "4",
-      "qwen3:8b": "4"
-    },
-    "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
-      "gpt-4o-mini": "4",
-      "qwen3:8b": "4"
-    },
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": "3"
-    },
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "qwen3:8b": "4"
-    },
-    "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
-      "qwen3:8b": "4"
-    },
-    "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
-      "qwen3:8b": "4"
-    },
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
-      "qwen3:8b": "4"
-    }
-  },
-  "Harpocrates": {
-    "Amulet depicting the god Harpocrates": {
+  "Amulet depicting the god Harpocrates": {
+    "Harpocrates": {
       "gpt-4o-mini": "1",
       "qwen3:8b": "1"
     }
   },
-  "Satet": {
-    "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Statue": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Bes": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Ptolemaic": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Roman": {
-    "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
-      "gpt-4o-mini": "5"
+  "Statuette of the goddess Satet. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 515": {
+    "Drovetti": {
+      "qwen3:8b": "4"
     },
-    "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
-      "gpt-4o-mini": "7"
+    "Satet": {
+      "gpt-4o-mini": "1"
     }
   },
-  "Horus": {
-    "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
+  "Magic stela of Horus on crocodiles. Limestone. Late Period - Ptolemaic Period (722-30 BC).. Drovetti collection (1824). C. 775": {
+    "Horus": {
       "gpt-4o-mini": "1",
       "qwen3:8b": "1"
+    },
+    "Drovetti": {
+      "qwen3:8b": "4"
     }
   },
-  "Apis": {
-    "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
+  "Statuette of the god Apis. Bronze. Late Period (722-332 BC).. Drovetti collection (1824). C. 0815": {
+    "Drovetti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Apis": {
       "gpt-4o-mini": "1"
     }
   },
-  "wedjat-eye": {
-    "Amulet depicting the wedjat-eye": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Amenhotep I": {
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
+  "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
+    "Amenhotep I": {
       "gpt-4o-mini": "1",
       "qwen3:8b": "1. the entity is a person depicted on or by the artefact"
-    }
-  },
-  "Deir el-Medina": {
-    "Cult statue of Amenhotep I. Limestone. New Kingdom, 19th Dynasty (1292–1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1372": {
+    },
+    "Deir el-Medina": {
       "gpt-4o-mini": "7",
       "qwen3:8b": "7. the entity is a location where the artefact was created"
     },
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
-      "gpt-4o-mini": "7"
-    },
-    "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
-      "gpt-4o-mini": "7"
-    },
-    "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
-      "gpt-4o-mini": "9"
-    },
-    "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333": {
-      "gpt-4o-mini": "9"
-    },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": "9"
-    },
-    "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
-      "gpt-4o-mini": "7"
-    },
-    "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
-      "gpt-4o-mini": "7"
-    },
-    "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
-      "gpt-4o-mini": "9"
-    },
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": "9"
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "9"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "9"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "9"
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": "9"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "9"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "9"
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": "9"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "9"
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "9"
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": "9"
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": "9"
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": "7"
-    },
-    "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965": {
-      "gpt-4o-mini": "9"
-    },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": "9"
+    "Drovetti": {
+      "qwen3:8b": "4"
     }
   },
-  "Ramesses II": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+  "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+    "Meh": {
+      "qwen3:8b": "1"
+    },
+    "Ramesses II": {
       "gpt-4o-mini": "5",
       "qwen3:8b": "5"
-    }
-  },
-  "Re": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+    },
+    "Heliopolis": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "Merenptah": {
+      "qwen3:8b": "5"
+    },
+    "Abydos": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Re": {
       "gpt-4o-mini": "6"
     }
   },
-  "Heliopolis": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+  "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
+    "Huy": {
+      "gpt-4o-mini": "2",
+      "qwen3:8b": "2"
+    },
+    "Deir el-Medina": {
       "gpt-4o-mini": "7",
       "qwen3:8b": "7. the entity is a location where the artefact was created"
     },
-    "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
-      "gpt-4o-mini": "9"
+    "Drovetti": {
+      "qwen3:8b": "4. the entity is a person that owned the artefact"
+    },
+    "Amun-Re": {
+      "gpt-4o-mini": "1"
     }
   },
-  "Abydos": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+  "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
+    "Aaner": {
+      "qwen3:8b": "4"
+    },
+    "Thebes": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "Drovetti": {
+      "qwen3:8b": "4"
+    },
+    "Book of the Dead of Aaner": {
+      "gpt-4o-mini": "4"
+    },
+    "Mut": {
+      "gpt-4o-mini": "1"
+    },
+    "Cyperus": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
+    "Iuefankh": {
+      "qwen3:8b": "4"
+    },
+    "Thebes": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "Book of the Dead of Iuefankh": {
+      "gpt-4o-mini": "11"
+    },
+    "Cyperus papyrus": {
+      "gpt-4o-mini": "11"
+    },
+    "Ptolemaic period": {
+      "gpt-4o-mini": "7"
+    },
+    "Drovetti collection": {
+      "gpt-4o-mini": "4"
+    }
+  },
+  "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
+    "Coffin of Tamutmutef": {
+      "qwen3:8b": "11. The entity is the person for whom the artefact was made (the deceased), which is not explicitly covered by any of the listed options."
+    },
+    "Thebes": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "Drovetti": {
+      "qwen3:8b": "4. the entity is a person that owned the artefact"
+    },
+    "Tamutmutef": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
+    "construction worker Mesmeni": {
+      "qwen3:8b": "4"
+    },
+    "Mesmeni": {
+      "gpt-4o-mini": "1"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "20th Dynasty": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
+    "Shabti of Horemakhbit": {
+      "qwen3:8b": "4"
+    },
+    "Deir el-Bahari": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Drovetti": {
+      "qwen3:8b": "4"
+    },
+    "Horemakhbit": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
+    "Khonsu": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "4"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "8. the entity is a location where the artefact was produced"
+    }
+  },
+  "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100": {
+    "Drovetti": {
+      "qwen3:8b": "4"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
+    "Tuthmosis III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Djehuty": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Drovetti": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "4"
+    },
+    "Tuthmosi III": {
+      "gpt-4o-mini": "5"
+    }
+  },
+  "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
+    "Amennakht": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "4"
+    },
+    "Drovetti": {
+      "qwen3:8b": "4"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
+    "Wadjren": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "1. the entity is a person depicted on or by the artefact"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Double juglet of the “Base Ring I” type, imported from Cyprus. Baked clay. New Kingdom, 18th Dynasty (1539-1292 BC).. Acquired before 1888. C. 3673": {
+    "Cyprus": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "8. the entity is a location where the artefact was produced"
+    }
+  },
+  "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
+    "Amenemope": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "4"
+    },
+    "Horemheb": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Saqqara": {
       "gpt-4o-mini": "9",
       "qwen3:8b": "9. the entity is a location where the artefact was discovered"
     }
   },
-  "Huy": {
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
-      "gpt-4o-mini": "2",
-      "qwen3:8b": "2"
-    }
-  },
-  "Amun-Re": {
-    "Stela dedicated by Huy to Amun-Re. Limestone. New Kingdom, 19th Dynasty (1292-1190 BC). Deir el-Medina.. Drovetti collection (1824). C. 1607": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Book of the Dead of Aaner": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Mut": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Cyperus": {
-    "Book of the Dead of Aaner, priest of Mut. Cyperus papyrus. Third Intermediate Period, 21st Dynasty (1076-944 BC). Thebes.. Drovetti collection (1824). C. 1771": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Book of the Dead of Iuefankh": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Cyperus papyrus": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Ptolemaic period": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Drovetti collection": {
-    "Book of the Dead of Iuefankh. Cyperus papyrus. Ptolemaic period (332-30 BC).. Thebes (?). Drovetti collection (1824). C. 1791": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Tamutmutef": {
-    "Coffin of Tamutmutef. Wood. Third Intermediate Period, 21st-22nd Dynasty (1076-746 BC). Thebes (?).. Drovetti collection (1824). C. 2228/1": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Ptolemaic Period": {
-    "Fragment of a mummy mask decorated with a mummification scene. Cartonnage. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2250": {
-      "gpt-4o-mini": "7"
-    },
-    "Coffin for a fish, containing mummy. Wood, organic remains. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2393/1": {
-      "gpt-4o-mini": "7"
-    },
-    "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
-      "gpt-4o-mini": "7"
-    },
-    "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Asiatic": {
-    "Mummy soles picturing two Asiatic prisoners, symbolizing the trampling of the enemy. Linen. Late Period (722-332 BC).. Acquired before 1882. C. 2328": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "25th Dynasty": {
-    "Shabti-box. Wood. Late Period, 25th Dynasty (722-664 BC). . Acquired before 1882. C. 2441": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Mesmeni": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "New Kingdom": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": "7"
-    },
-    "Male statue. Wood. New Kingdom, 19th Dynasty (1292-1190 BC).. Drovetti collection (1824). C. 3100": {
-      "gpt-4o-mini": "7"
-    },
-    "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
-      "gpt-4o-mini": "7"
-    },
-    "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
-      "gpt-4o-mini": "7"
-    },
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": "7"
-    },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": "7"
-    },
-    "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
-      "gpt-4o-mini": "7"
-    },
-    "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
-      "gpt-4o-mini": "7"
-    },
-    "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
-      "gpt-4o-mini": "7"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "5"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "5"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "5"
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": "7"
-    },
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "20th Dynasty": {
-    "Shabti of the construction worker Mesmeni. Baked clay. New Kingdom, 20th Dynasty (1190-1076 BC).. Acquired before 1882. C. 2646": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Horemakhbit": {
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Deir el-Bahari": {
-    "Shabti of Horemakhbit. Faience. Third Intermediate Period, 21st Dynasty (1076-944 BC). Deir el-Bahari, Second Cachette.. Drovetti collection (1824). C. 2724/a": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Khonsu": {
-    "Shabti of Khonsu. Wood. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Acquired before 1882. C. 2737 v.n. 915": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Tuthmosis III": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": "5"
-    },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Djehuty": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Tuthmosi III": {
-    "Ointment jar with the cartouche of Tuthmosis III and an indication of its capacity, probably from the grave-goods of the overseer of foreign lands Djehuty. Calcite (alabaster). New Kingdom, 18th Dynasty, reign of Tuthmosi III (1458-1425 a.C.).. Drovetti ": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Amennakht": {
-    "Dummy jar of Amennakht. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC).. Drovetti collection (1824). C. 3325": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Wadjren": {
-    "Lid of canopic jar of Wadjren, overseer of the two granaries. Baked clay. New Kingdom, 18th Dynasty, ca. 1450-1400 BC.. Acquired before 1882. C. 3459/b": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Cyprus": {
-    "Double juglet of the “Base Ring I” type, imported from Cyprus. Baked clay. New Kingdom, 18th Dynasty (1539-1292 BC).. Acquired before 1888. C. 3673": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "1888": {
-    "Scarab. Faience. Late Period – Ptolemaic Period (722-30 BC).. Acquired before 1888. C. 6098": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Amenemope": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Horemheb": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Saqqara": {
-    "Royal cubit rod of Amenemope, overseer of the two granaries. Wood. New Kingdom, 18th Dynasty, reign of Horemheb (1319-1292 BC). Saqqara (?).. Drovetti collection (1824). C. 6347": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Roman Period": {
-    "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
-      "gpt-4o-mini": "11"
-    },
-    "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
-      "gpt-4o-mini": "11"
-    },
-    "Lid. Glass. Roman Period (30 BC-AD 395).. P. 5178": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "deity": {
-    "Amulet depicting a hybrid deity": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "heart": {
-    "Amulet depicting the heart": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Attis": {
-    "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Nephthys": {
-    "Amulet depicting the goddess Nephthys": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Calcite": {
-    "Dish. Calcite (alabaster). Early Dynastic Period, 1st-2nd Dynasty (3000-2590 BC).. P. 795": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Tamit": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": "9"
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Egyptian Nubia": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": "7"
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Istituto Egittologia": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": "9"
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "University of Rome": {
-    "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
-      "gpt-4o-mini": "9"
-    },
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "worshiper": {
-    "Statuette of a worshiper. Bronze. Late Period (722-332 BC).. P. 3552": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Nubia": {
-    "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Amulet": {
-    "Amulet depicting the god Nefertum": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Nefertum": {
-    "Amulet depicting the god Nefertum": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Shabti": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": "11"
-    },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": "11. other entity type or other relation between entity and artefact"
-    }
-  },
-  "Alabaster": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Museo Kircheriano": {
-    "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
-      "gpt-4o-mini": "10"
-    }
-  },
-  "Naqada": {
-    "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
-      "gpt-4o-mini": "7"
-    },
-    "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
-      "gpt-4o-mini": "7"
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Schiaparelli": {
-    "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
-      "gpt-4o-mini": "4"
-    },
-    "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
-      "gpt-4o-mini": "4"
-    },
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
-      "gpt-4o-mini": "4"
-    },
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": "4"
-    },
-    "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
-      "gpt-4o-mini": "4."
-    },
-    "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
-      "gpt-4o-mini": "3"
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "gpt-4o-mini": "3"
-    },
-    "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
-      "gpt-4o-mini": "3"
-    },
-    "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
-      "gpt-4o-mini": "3"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "3"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "3"
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": "3"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "3"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "3"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "3"
-    },
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "3"
-    },
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": "3"
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": "3"
-    },
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": "3"
-    },
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": "3"
-    },
-    "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
-      "gpt-4o-mini": "3"
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
-      "gpt-4o-mini": "3"
-    },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
-      "gpt-4o-mini": "3"
-    },
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": "3"
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": "3"
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": "3"
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": "3"
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": "3"
-    },
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": "3"
-    },
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": "3"
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": "3"
-    },
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": "3"
-    },
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Predynastic Period": {
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Naqada II": {
-    "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "oarsmen": {
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Asyut": {
-    "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
-      "gpt-4o-mini": "7"
-    },
-    "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
-      "gpt-4o-mini": "9"
-    },
-    "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141": {
-      "gpt-4o-mini": "9"
-    },
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "9"
-    },
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": "9"
-    },
-    "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Stela of Inheretnakht": {
-    "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Hammamiya": {
-    "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Valley of the Queens": {
-    "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "African man": {
-    "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Djefahapi": {
-    "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Amenhotep II": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": "5"
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "5"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "5"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "5"
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": "5"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "5"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "5"
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": "5"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "5"
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "5"
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": "5"
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Tuthmosis IV": {
-    "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
-      "gpt-4o-mini": "5"
-    },
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "5"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "5"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "5"
-    },
-    "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
-      "gpt-4o-mini": "5"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "5"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "5"
-    },
-    "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
-      "gpt-4o-mini": "5"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "5"
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "5"
-    },
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": "5"
-    },
-    "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Bowl": {
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "11"
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Kha": {
-    "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
-      "gpt-4o-mini": "9"
-    },
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "4"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "4"
-    },
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "4"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "4"
-    },
-    "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
-      "gpt-4o-mini": "4"
-    },
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Persea": {
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "papyrus": {
-    "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
-      "gpt-4o-mini": "11"
-    },
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Pestle": {
-    "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "18th Dynasty": {
-    "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
-      "gpt-4o-mini": "5"
-    },
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Lidded basket": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "juniper berries": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Vegetable fibers": {
-    "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Tunic": {
-    "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Kohl tube": {
-    "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Cup": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "11"
-    },
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Baked clay": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Middle Kingdom": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "12th Dynasty": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Sesostris I": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Shemes": {
-    "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Tomb of Minhotep": {
-    "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Tomb": {
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Minhotep": {
-    "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Menna": {
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Ramesses III": {
-    "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Nespayherhat": {
-    "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Gebelein": {
-    "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
-      "gpt-4o-mini": "9"
-    },
-    "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
-      "gpt-4o-mini": "9"
-    },
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
-      "gpt-4o-mini": "9"
-    },
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": "9"
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": "9"
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": "9"
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": "9"
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "gpt-4o-mini": "9"
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": "9"
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": "9"
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
-      "gpt-4o-mini": "9"
-    },
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": "9"
-    },
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": "9"
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": "9"
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": "9"
-    },
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Hathor": {
-    "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Iti": {
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": "4"
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": "4"
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": "4"
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": "4"
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "gpt-4o-mini": "4"
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": "4"
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": "4"
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": "1"
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Neferu": {
-    "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
-      "gpt-4o-mini": "4"
-    },
-    "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
-      "gpt-4o-mini": "4"
-    },
-    "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
-      "gpt-4o-mini": "1"
-    },
-    "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
-      "gpt-4o-mini": "4"
-    },
-    "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
-      "gpt-4o-mini": "4"
-    },
-    "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
-      "gpt-4o-mini": "4"
-    },
-    "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
-      "gpt-4o-mini": "4"
-    },
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": "1"
-    },
-    "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Mummy": {
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Ini": {
-    "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Old Kingdom": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "5th Dynasty": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "1911": {
-    "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "greyhound": {
-    "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
-      "gpt-4o-mini": "11"
-    }
-  },
-  "Perim": {
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Shepset": {
-    "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
-      "gpt-4o-mini": "1"
-    }
-  },
-  "Fayum": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Hawara": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Garré": {
-    "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
-      "gpt-4o-mini": "4"
-    }
-  },
-  "Byzantine Period": {
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
-      "gpt-4o-mini": "7"
-    }
-  },
-  "Museum of Cairo": {
-    "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
-      "gpt-4o-mini": "10"
-    }
-  },
-  "Akhenaten": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": "5"
-    }
-  },
-  "Munich": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": "10"
-    }
-  },
-  "Turin Rotary Club": {
-    "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
-      "gpt-4o-mini": "10"
-    }
-  },
-  "Tebtynis": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
-      "gpt-4o-mini": "9"
-    },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Anti": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
-      "gpt-4o-mini": "9"
-    },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Bagnani": {
-    "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
-      "gpt-4o-mini": "3"
-    },
-    "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
-      "gpt-4o-mini": "9"
-    }
-  },
-  "Tom": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
-      "qwen3:0.6b": "11"
-    },
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "qwen3:0.6b": "6"
-    }
-  },
-  "Egyptian Museum": {
-    "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
-      "qwen3:0.6b": "6"
-    }
-  },
-  "New York": {
-    "Statue of the goddess Sekhmet. Granodiorite. New Kingdom, 18th Dynasty, reign of Amenhotep III (1390-1353 BC). Thebes.. Drovetti collection (1824). C. 256": {
-      "qwen3:0.6b": "6"
-    }
-  },
-  "Meh": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+  "Amulet depicting the goddess Nephthys": {
+    "Nephthys": {
+      "gpt-4o-mini": "1",
       "qwen3:8b": "1"
     }
   },
-  "Merenptah": {
-    "Stela of Meh, scribe of the treasury in the temple of Ramesses II in the sanctuary of Re (in Heliopolis). Limestone. New Kingdom, 19th Dynasty, second half of the reign of Ramesses II-early reign of Merenptah, ca. 1240-1210 BC. Abydos (?).. Acquired befor": {
+  "Statuette of the god Anubis. Bronze. Late Period (722-332 BC).. Acquired before 1882. C. 115": {
+    "Anubis": {
+      "gpt-4o-mini": "1",
+      "qwen3:0.6b": "1"
+    },
+    "Tom": {
+      "qwen3:0.6b": "11"
+    },
+    "Egyptian Museum": {
+      "qwen3:0.6b": "6"
+    }
+  },
+  "Bread loaf. Vegetable organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8273": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
       "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "New Kingdom": {
+      "qwen3:8b": "11. The entity \"New Kingdom\" is mentioned to indicate the historical period during which the artefact was created, which is a time period rather than a person or location."
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "18th Dynasty": {
+      "qwen3:8b": "5"
+    },
+    "Bread loaf": {
+      "qwen3:8b": "11. the entity is the artefact's own name or type, not a person or location."
+    },
+    "Vegetable organic remains": {
+      "qwen3:8b": "11. The entity refers to the material composition of the artefact (bread loaf), indicating the ingredients (vegetable organic remains) used in its creation, not a person, location, or other relation listed in the options."
+    },
+    "Tomb of Kha": {
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "S. 8273": {
+      "qwen3:8b": "11. The entity \"S. 8273\" is likely a catalog or inventory number assigned by the museum, which is not explicitly covered by the provided options. It refers to the artefact's record within the museum's collection, not directly to a person, location, or ownership."
+    }
+  },
+  "Bowl containing fishes dried in salt. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8321": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Bowl": {
+      "gpt-4o-mini": "11"
+    },
+    "Kha": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "4. the entity is a person that owned the artefact"
+    }
+  },
+  "Persea and papyrus twigs. Vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8352": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5. the entity is a person in power during the period of the creation of the artefact"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "5"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4"
+    },
+    "Persea": {
+      "gpt-4o-mini": "11"
+    },
+    "papyrus": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Pestle or papyrus smoother. Wood. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8364": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4"
+    },
+    "papyrus": {
+      "gpt-4o-mini": "11"
+    },
+    "Pestle": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Decorated ware. Baked clay. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8368": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "qwen3:8b": "4"
+    }
+  },
+  "Salt loaf. Salt. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8410": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5. the entity is a person in power during the period of the creation of the artefact"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "5"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5. the entity is a person in power during the period of the creation of the artefact"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "18th Dynasty": {
+      "gpt-4o-mini": "5"
+    }
+  },
+  "Lidded basket with juniper berries. Vegetable fibers, organic remains. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8414": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "5"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5. the entity is a person in power during the period of the creation of the artefact"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "18th Dynasty": {
+      "gpt-4o-mini": "5"
+    },
+    "Lidded basket": {
+      "gpt-4o-mini": "11"
+    },
+    "juniper berries": {
+      "gpt-4o-mini": "11"
+    },
+    "Vegetable fibers": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Basket. Wood, vegetable fibers. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8424": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5. the entity is a person in power during the period of the creation of the artefact"
+    }
+  },
+  "Inner coffin of Kha. Wood, stucco, gold, bronze, glass. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8429": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Tunic with multicolored borders. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8530": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "gpt-4o-mini": "4"
+    },
+    "Tunic": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Kohl tube with linen stopper. Vegetable fibers, linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8606": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Kha": {
+      "qwen3:8b": "4"
+    },
+    "Kohl tube": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Loincloth. Linen. New Kingdom, 18th Dynasty, reigns of Amenhotep II, Tuthmosis IV and Amenhotep III (1425-1353 BC). Deir el-Medina, Tomb of Kha (TT 8).. Schiaparelli excavations (1906). S. 8613/10": {
+    "Amenhotep III": {
+      "gpt-4o-mini": "5"
+    },
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9"
+    },
+    "Amenhotep II": {
+      "gpt-4o-mini": "5"
+    },
+    "Tuthmosis IV": {
+      "gpt-4o-mini": "5"
+    }
+  },
+  "Statue of the god Bes. Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1882. C. 638": {
+    "Statue": {
+      "gpt-4o-mini": "11"
+    },
+    "Bes": {
+      "gpt-4o-mini": "1"
+    },
+    "Ptolemaic": {
+      "gpt-4o-mini": "5"
+    },
+    "Roman": {
+      "gpt-4o-mini": "5"
+    }
+  },
+  "Statuette of the Near Eastern god Attis, god of fertility, wearing a Phrygian cap. Baked clay. Roman Period (30 BC-AD 395).. Acquired before 1888. C. 7238": {
+    "Roman": {
+      "gpt-4o-mini": "7"
+    },
+    "Attis": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Amulet depicting the wedjat-eye": {
+    "wedjat-eye": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Painted ostracon with the head of an African man with short curly hair and an earring. Limestone, black ink. New Kingdom, 20th Dynasty (1186–1069 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6295": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "African man": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Illustrated ostracon showing animals performing the parody of a religious procession. Limestone. New Kingdom, 19th-20th Dynasty (1292-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6333": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    }
+  },
+  "Jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 6994": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    }
+  },
+  "Decorated jar. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7013": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    }
+  },
+  "Bowl. Baked clay. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7074": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    }
+  },
+  "Brush. Vegetable fibers. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1905). S. 7660": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    }
+  },
+  "Hieratic ostracon with a testimony in court by the workman Menna. Limestone. New Kingdom, 20th Dynasty, reign of Ramesses III (1187-1157 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 9611 = CGT 57381": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Menna": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "11. the entity is mentioned in the content of the artefact as a person involved in the recorded testimony"
+    },
+    "Ramesses III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    }
+  },
+  "Two chisels. Wood, bronze. New Kingdom, 18th-20th Dynasty (1539-1076 BC). Deir el-Medina.. Schiaparelli excavations (1909-1912). S. 09964 e 09965": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    }
+  },
+  "Shabti of Nespayherhat. Baked clay. Third Intermediate Period, 21st- 22nd Dynasty (1076-746 BC). Deir el-Medina.. Schiaparelli excavations (1909). S. 10437": {
+    "Deir el-Medina": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Shabti": {
+      "gpt-4o-mini": "11. other entity type or other relation between entity and artefact"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Nespayherhat": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "1. the entity is a person depicted on or by the artefact"
+    }
+  },
+  "Cosmetic palette. Limestone. Predynastic Period, Naqada IIC-IIIA (3500-3200 BC). Heliopolis.. Schiaparelli excavations (1906). S. 4034/1": {
+    "Heliopolis": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    }
+  },
+  "Fragment of a mummy mask decorated with a mummification scene. Cartonnage. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2250": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Coffin for a fish, containing mummy. Wood, organic remains. Ptolemaic Period (332-30 BC).. Acquired before 1882. C. 2393/1": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Loom weight. Baked clay. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 6391": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": "7"
+    },
+    "Roman Period": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Mold for amulets depicting the benu bird (phoenix). Limestone. Ptolemaic Period - Roman Period (332 BC - AD 395).. Acquired before 1888. C. 7067": {
+    "Ptolemaic Period": {
+      "gpt-4o-mini": "7"
+    },
+    "Roman Period": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Mummy soles picturing two Asiatic prisoners, symbolizing the trampling of the enemy. Linen. Late Period (722-332 BC).. Acquired before 1882. C. 2328": {
+    "Asiatic": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Shabti-box. Wood. Late Period, 25th Dynasty (722-664 BC). . Acquired before 1882. C. 2441": {
+    "25th Dynasty": {
+      "gpt-4o-mini": "5"
+    }
+  },
+  "Shabti. Alabaster. New Kingdom (1539-1076 BC).. Museo Kircheriano (1896). S. 166": {
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Shabti": {
+      "gpt-4o-mini": "11"
+    },
+    "Alabaster": {
+      "gpt-4o-mini": "11"
+    },
+    "Museo Kircheriano": {
+      "gpt-4o-mini": "10",
+      "qwen3:8b": "10"
+    }
+  },
+  "Talatat. Limestone. New Kingdom, 18th Dynasty, reign of Akhenaten (1353-1336 BC).. Purchased in Munich (1970), gift of the Turin Rotary Club. S. 18143": {
+    "New Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "Akhenaten": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Munich": {
+      "gpt-4o-mini": "10",
+      "qwen3:8b": "9"
+    },
+    "Turin Rotary Club": {
+      "gpt-4o-mini": "10"
+    },
+    "Turin": {
+      "qwen3:8b": "10. the entity is the artefact's current location"
+    }
+  },
+  "Model brick stamp with the cartouche of Tuthmosis III “beloved of Hathor, mistress of Gebelein”. Wood. New Kingdom, reign of Tuthmosis III (1458-1425 BC). Gebelein, temple of Hathor, under the foundations.. Schiaparelli excavations (1910). S. 12445": {
+    "Tuthmosis III": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Hathor": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Scarab. Faience. Late Period – Ptolemaic Period (722-30 BC).. Acquired before 1888. C. 6098": {
+    "1888": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Lid. Glass. Roman Period (30 BC-AD 395).. P. 5178": {
+    "Roman Period": {
+      "gpt-4o-mini": "7"
+    }
+  },
+  "Amulet depicting a hybrid deity": {
+    "deity": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Amulet depicting the heart": {
+    "heart": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Dish. Calcite (alabaster). Early Dynastic Period, 1st-2nd Dynasty (3000-2590 BC).. P. 795": {
+    "Calcite": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Pendant in rock crystal forming part of a necklace with other eleven perforated shells (P. 3539/1-11). Rock crystal. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome": {
+    "Tamit": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Egyptian Nubia": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Istituto Egittologia": {
+      "gpt-4o-mini": "9"
+    },
+    "University of Rome": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Tomb N. 1": {
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    }
+  },
+  "Globular vessel with a grey washing. Backed clay. Predynastic Period, late 4th millennium BC. Tamit, Egyptian Nubia, Tomb N. 1.. Excavations of the Istituto Egittologia, University of Rome in Nubia (1964) (on loan). P. 3645": {
+    "Tamit": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9"
+    },
+    "Egyptian Nubia": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Istituto Egittologia": {
+      "gpt-4o-mini": "9"
+    },
+    "University of Rome": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "3"
+    },
+    "Nubia": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Tomb N. 1": {
+      "qwen3:8b": "9"
+    }
+  },
+  "Statuette of a worshiper. Bronze. Late Period (722-332 BC).. P. 3552": {
+    "worshiper": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Amulet depicting the god Nefertum": {
+    "Amulet": {
+      "gpt-4o-mini": "11"
+    },
+    "Nefertum": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Mace head. Granodiorite. Predynastic Period, Naqada I-IIB (3900-3550 BC).. Purchased by Schiaparelli (1900-1901). S. 569": {
+    "Naqada": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Naqada I-IIB": {
+      "qwen3:8b": "11. The entity is a time period (Naqada I-IIB) during which the artefact was created, which is not explicitly covered by the provided options."
+    }
+  },
+  "Animal-shaped tag. Bone, ivory. Predynastic Period, Naqada I-IIA (3900-3600 BC).. Purchased by Schiaparelli (1900-1901). S. 1121": {
+    "Naqada": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Wavy-handled jar (W-ware). Baked clay. Predynastic Period, Naqada IIC (3500-3400 BC). Hammamiya.. Schiaparelli excavations (1905). S. 4721": {
+    "Naqada": {
+      "gpt-4o-mini": "7"
+    },
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Hammamiya": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Naqada IIC": {
+      "qwen3:8b": "11. The entity \"Naqada IIC\" refers to a cultural and chronological period (Predynastic Period, 3500-3400 BC), not a person, location, or other entity type listed in the options. It denotes the time during which the artefact was created, which is not explicitly covered by the provided choices."
+    }
+  },
+  "Animal-shaped amulet. Serpentine. Predynastic Period, Naqada II (3700-3300 BC).. Purchased by Schiaparelli (1900-1901). S. 1166/1": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Predynastic Period": {
+      "gpt-4o-mini": "7"
+    },
+    "Naqada II": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "11. The entity is a period during which the artefact was created, which is not explicitly covered by the provided options."
+    }
+  },
+  "Boat model with oarsmen and a coffin under a canopy. Wood. Middle Kingdom, 11th Dynasty (1980-1939 BC). Asyut (?).. Purchased by Schiaparelli (1900-1901). S. 1208": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "oarsmen": {
+      "gpt-4o-mini": "1"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    }
+  },
+  "Stela of Inheretnakht. Limestone. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC).. Purchased by Schiaparelli (1900-1901). S. 1264": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "4.",
+      "qwen3:8b": "4"
+    },
+    "Stela of Inheretnakht": {
+      "gpt-4o-mini": "11"
+    },
+    "Inheretnakht": {
+      "qwen3:8b": "1"
+    }
+  },
+  "Two scarabs. Faïence. Late Period, 25th-31st Dynasty (722-332 BC). Valley of the Queens.. Schiaparelli excavations (1903-1905). S. 5329/1-2": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Valley of the Queens": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    }
+  },
+  "Cup. Baked clay. Middle Kingdom, 12th Dynasty, reign of Sesostris I (1920-1875 BC). Asyut, Tomb of Shemes.. Schiaparelli excavations (1908). S. 8676": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Cup": {
+      "gpt-4o-mini": "11"
+    },
+    "Baked clay": {
+      "gpt-4o-mini": "11"
+    },
+    "Middle Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "12th Dynasty": {
+      "gpt-4o-mini": "5"
+    },
+    "Sesostris I": {
+      "gpt-4o-mini": "5",
+      "qwen3:8b": "5"
+    },
+    "Shemes": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "4"
+    }
+  },
+  "Jar. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8812": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Tomb of Minhotep": {
+      "gpt-4o-mini": "9"
+    },
+    "Minhotep": {
+      "qwen3:8b": "4"
+    }
+  },
+  "Cup. Baked clay. Middle Kingdom, early 12th Dynasty (1939-1875 BC). Asyut, Tomb of Minhotep.. Schiaparelli excavations (1908). S. 8853": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Asyut": {
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Cup": {
+      "gpt-4o-mini": "11"
+    },
+    "Tomb of Minhotep": {
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Tomb": {
+      "gpt-4o-mini": "9"
+    },
+    "Minhotep": {
+      "gpt-4o-mini": "9"
+    }
+  },
+  "Black-topped vase (B-ware). Baked clay. Predynastic Period, Naqada I-IIA (3900-3600 BC). Gebelein.. Schiaparelli excavations (1910). S. 11113/2": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    }
+  },
+  "Wavy-handled jar (W-ware). Baked clay. Protodynastic Period, Naqada IIIA1 (3300-3200 BC). Gebelein.. Schiaparelli excavations (1910). S. 11170": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    }
+  },
+  "Jar with lid. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13054": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "11. The entity \"Iti\" is mentioned as part of the tomb's name (tomb of Iti and Neferu) where the artefact was discovered. This indicates Iti was a person associated with the burial site, not directly related to the artefact's creation, discovery, or ownership, but linked to the location context."
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13066": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Shell. Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13084": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "1"
+    }
+  },
+  "Jar. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13165": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Bowl. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13254": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Bowl": {
+      "gpt-4o-mini": "11"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Mummy of Ini. Organic remains. Early First Intermediate Period (ca. 2090 BC). Gebelein, Northern Cemetery, Tomb of Ini.. Schiaparelli excavations (1911). S. 13268": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "7. the entity is a location where the artefact was created"
+    },
+    "Mummy": {
+      "gpt-4o-mini": "11"
+    },
+    "Ini": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Jug. Baked clay. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, “Tomba Grande”.. Schiaparelli excavations (1911). S. 13991": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Old Kingdom": {
+      "gpt-4o-mini": "7"
+    },
+    "5th Dynasty": {
+      "gpt-4o-mini": "5"
+    },
+    "1911": {
+      "gpt-4o-mini": "9"
+    },
+    "Jug": {
+      "qwen3:8b": "11. The entity is the artefact's type or category (the object itself is a jug)."
+    },
+    "Tomba Grande": {
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    }
+  },
+  "Pittura parietale: offering bearers and a sacrifice scene. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/12": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "4"
+    }
+  },
+  "Offering basin of Perim and Shepset. Limestone. Old Kingdom, 5th Dynasty (2435-2305 BC). Gebelein, mastaba of Perim.. Schiaparelli excavations (1914). S. 15736": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Perim": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "4"
+    },
+    "Shepset": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "4"
+    }
+  },
+  "Decoration for tunic cuffs with geometric design on purple background. Linen, wool. Byzantine Period, 5th – 6th century AD.. Purchased by Schiaparelli or gift by the Museum of Cairo (1900-1901). S. 17486": {
+    "Schiaparelli": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Byzantine Period": {
+      "gpt-4o-mini": "7"
+    },
+    "Museum of Cairo": {
+      "gpt-4o-mini": "10",
+      "qwen3:8b": "11. The entity is a location where the artefact was previously located (previous owner), which is not explicitly covered by the other options."
+    }
+  },
+  "Funerary basket. Wood, vegetable fibers. Old Kingdom, 5th-6th Dynasty (2435-2118 BC). Asyut, burial shaft in front of Djefahapi’s tomb.. Schiaparelli excavations (1906). S. 7932/1": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Djefahapi": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "4. the entity is a person that owned the artefact"
+    }
+  },
+  "Offering tray. Baked clay. First Intermediate Period, 8th-11th Dynasty (2118-1980 BC). Asyut.. Schiaparelli excavations (1906). S. 8141": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    }
+  },
+  "Mummy of an ibis. Organic remains, linen. Ptolemaic Period - Roman Period (3rd century BC - 3rd century AD). Asyut.. Schiaparelli excavations (1910). S. 11029": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Asyut": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    }
+  },
+  "Flask. Glazed clay. New Kingdom (1539-1076 BC) (?). Gebelein, found inside the tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13111": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Miniature vase. Baked clay. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13255": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Iti": {
+      "qwen3:8b": "4. the entity is a person that owned the artefact"
+    },
+    "Neferu": {
+      "qwen3:8b": "4"
+    }
+  },
+  "Wall painting: Iti with greyhound. Tempera painting on clay and straw. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 14354/01": {
+    "Schiaparelli": {
+      "qwen3:8b": "3"
+    },
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Iti": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "1"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "1",
+      "qwen3:8b": "1. the entity is a person depicted on or by the artefact"
+    },
+    "greyhound": {
+      "gpt-4o-mini": "11"
+    }
+  },
+  "Model bag. Vegetable fibers. First Intermediate Period (2118-1980 BC). Gebelein, tomb of Iti and Neferu.. Schiaparelli excavations (1911). S. 13108": {
+    "Gebelein": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Iti": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    },
+    "Neferu": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Gilded covering for a female mummy. Gilt cartonnage. Roman Period, 2nd century AD. Fayum, Hawara (?).. Gift of Garré. S. 17134": {
+    "Fayum": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Hawara": {
+      "gpt-4o-mini": "7",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Garré": {
+      "gpt-4o-mini": "4",
+      "qwen3:8b": "4"
+    }
+  },
+  "Colored glass inlay. Glass. Ptolemaic Period (332-30 BC). Tebtynis.. Anti and Bagnani excavations (1930-1935). S. 18556/03": {
+    "Tebtynis": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "9. the entity is a location where the artefact was discovered"
+    },
+    "Anti": {
+      "gpt-4o-mini": "9",
+      "qwen3:8b": "3. the entity is a person that discovered the artefact"
+    },
+    "Bagnani": {
+      "gpt-4o-mini": "3",
+      "qwen3:8b": "3"
+    }
+  },
+  "Anthropoid coffin with remains of a painted decoration. Wood. Ptolemaic Period - Roman Period (332 BC-AD 395). Tebtynis ?. Anti and Bagnani excavations (1930-1935). S. 19691": {
+    "Tebtynis": {
+      "gpt-4o-mini": "9"
+    },
+    "Anti": {
+      "gpt-4o-mini": "9"
+    },
+    "Bagnani": {
+      "gpt-4o-mini": "9"
     }
   }
 }


### PR DESCRIPTION
Added evaluation for the Linking task, for the Egyptian Museum data set:

* processed data set with Qwen on Google Colab
* stored processed data in file linking_cache.json
* created gold standard data for the Linking task
* stored gold standard data in file disambiguation_gold.json
* re-implemented evaluation code: HIPE-scorer is unreliable
* added new evaluation code to file utils.py
* updated file demo-qwen.ipynb
* tested file demo-qwen.ipynb on laptop and Google Colab ✅

❌ Note: did not update the separate task notebooks. These might be broken now since a lot of the underlying code in utils.py has changed